### PR TITLE
[Internal Manager] Add polygon , fix Optimism and remove Sepolia from networks

### DIFF
--- a/apps/balancer-tools/src/app/internalmanager/layout.tsx
+++ b/apps/balancer-tools/src/app/internalmanager/layout.tsx
@@ -29,6 +29,8 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               Network.Ethereum,
               Network.Gnosis,
               Network.Arbitrum,
+              Network.Polygon,
+              Network.PolygonZKEVM,
               Network.Optimism,
               Network.Goerli,
               Network.Sepolia,

--- a/apps/balancer-tools/src/app/internalmanager/layout.tsx
+++ b/apps/balancer-tools/src/app/internalmanager/layout.tsx
@@ -33,7 +33,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               Network.PolygonZKEVM,
               Network.Optimism,
               Network.Goerli,
-              Network.Sepolia,
             ]}
             chainName={network}
           >

--- a/apps/balancer-tools/src/contexts/networks.tsx
+++ b/apps/balancer-tools/src/contexts/networks.tsx
@@ -14,6 +14,8 @@ export function getNetwork(chainName?: string) {
       ? "arbitrum"
       : chainName?.toLowerCase() === "polygon zkevm"
       ? "polygon-zkevm"
+      : chainName?.toLowerCase() === "op mainnet"
+      ? "optimism"
       : chainName?.toLowerCase();
   return network as Network;
 }
@@ -27,7 +29,7 @@ interface NetworksContextI {
 }
 
 export const NetworksContext = React.createContext<NetworksContextI>(
-  {} as NetworksContextI,
+  {} as NetworksContextI
 );
 
 export const NetworksContextProvider = ({
@@ -52,7 +54,7 @@ export const NetworksContextProvider = ({
       networkConnectedToWallet !== network.chain?.id
     ) {
       push(
-        `/${appName}/${networkFor(network.chain.id).toLowerCase()}` as Route,
+        `/${appName}/${networkFor(network.chain.id).toLowerCase()}` as Route
       );
     }
   }, [network]);

--- a/apps/balancer-tools/src/lib/gql.ts
+++ b/apps/balancer-tools/src/lib/gql.ts
@@ -14,7 +14,7 @@ import { GraphQLClient } from "graphql-request";
 
 export function impersonateWhetherDAO(
   chainId: string,
-  address: Address | undefined,
+  address: Address | undefined
 ) {
   const network = networkFor(chainId);
 
@@ -57,7 +57,7 @@ export const gauges = {
 };
 
 export const internalBalances = {
-  client: clientFor(Subgraph.BalancerInternalManager),
+  client: clientFor(Subgraph.BalancerPools),
   gql: (chainId: string) =>
     internalManagerSdks[networkFor(chainId)](internalBalances.client(chainId)),
 };

--- a/packages/gql/codegen.ts
+++ b/packages/gql/codegen.ts
@@ -5,7 +5,6 @@ export enum Subgraph {
   BalancerPoolsMetadata = "balancer-pools-metadata",
   BalancerGauges = "balancer-gauges",
   BalancerPools = "balancer-pools",
-  BalancerInternalManager = "balancer-internal-manager",
 }
 
 // IMPORTANT NOTE:
@@ -70,34 +69,13 @@ export const SUBGRAPHS = {
 
       return {
         [Network.Ethereum]: `${baseEndpoint}/balancer-v2`,
-        [Network.Sepolia]: `https://api.studio.thegraph.com/query/24660/balancer-sepolia-v2/version/latest`,
+        [Network.Sepolia]: `https://api.studio.thegraph.com/query/46539/balancer-sepolia-v2/v0.0.1`,
         [Network.Goerli]: `${baseEndpoint}/balancer-goerli-v2`,
         [Network.Polygon]: `${baseEndpoint}/balancer-polygon-v2`,
         [Network.PolygonZKEVM]: `https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2/version/latest`,
-        [Network.Arbitrum]: `${baseEndpoint}/balancer-arbitrum-v2`,
+        //TODO: substitute Arbitrum to balancer-labs subgraph once it shows tokenInfo
+        [Network.Arbitrum]: `https://api.thegraph.com/subgraphs/name/bleu-studio/balancer-arbitrum-v2`,
         [Network.Gnosis]: `${baseEndpoint}/balancer-gnosis-chain-v2-beta`,
-        [Network.Optimism]: `${baseEndpoint}/balancer-optimism-v2`,
-      };
-    },
-    endpointFor(network: Network) {
-      return this.endpoints()[network];
-    },
-  },
-  [Subgraph.BalancerInternalManager]: {
-    name: Subgraph.BalancerInternalManager,
-    endpoints() {
-      //This is a fork of the pools subgraph that's to be merged to Balancer's own subgraph
-      const baseEndpoint =
-        "https://api.thegraph.com/subgraphs/name/bleu-studio";
-      return {
-        // TODO: deploy subgraph on mainnet, polygon and arbitrum
-        [Network.Ethereum]: `${baseEndpoint}/balancer-mainnet-v2`,
-        [Network.Sepolia]: `https://api.studio.thegraph.com/query/46539/balancer-sepolia-v2/v0.0.1`,
-        [Network.Goerli]: `${baseEndpoint}/balancer-v2-goerli`,
-        [Network.Polygon]: `${baseEndpoint}/balancer-polygon-v2`,
-        [Network.PolygonZKEVM]: `${baseEndpoint}/balancer-polygon-v2`,
-        [Network.Arbitrum]: `${baseEndpoint}/balancer-arbitrum-v2`,
-        [Network.Gnosis]: `${baseEndpoint}/balancer-gnosis-v2`,
         [Network.Optimism]: `${baseEndpoint}/balancer-optimism-v2`,
       };
     },
@@ -139,9 +117,9 @@ const generates = Object.assign(
             },
           ],
         ])
-        .flat(1),
-    ),
-  ),
+        .flat(1)
+    )
+  )
 );
 
 const config: CodegenConfig = {

--- a/packages/gql/codegen.ts
+++ b/packages/gql/codegen.ts
@@ -69,7 +69,7 @@ export const SUBGRAPHS = {
 
       return {
         [Network.Ethereum]: `${baseEndpoint}/balancer-v2`,
-        [Network.Sepolia]: `https://api.studio.thegraph.com/query/46539/balancer-sepolia-v2/v0.0.1`,
+        [Network.Sepolia]: `https://api.studio.thegraph.com/query/24660/balancer-sepolia-v2/version/latest`,
         [Network.Goerli]: `${baseEndpoint}/balancer-goerli-v2`,
         [Network.Polygon]: `${baseEndpoint}/balancer-polygon-v2`,
         [Network.PolygonZKEVM]: `https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2/version/latest`,


### PR DESCRIPTION
This PR:
- adds Polygon
- fix Optimism url check on `getNetwork`
- remove sepolia from networks, because viem is not recognizing successful transactions
- remove `Subgraph.BalancerInternalManager` since `Subgraph.BalancerPools` now has `tokenInfo` on `userInternalBalances` query

Tested networks - Show token table:
- Ethereum -> Ok;
- Goerli -> Ok;
- Sepolia -> Ok;
- Polygon -> Ok;
- Polygon zkevm -> Ok;
- Gnosis -> Ok;
- Arbitrum -> Ok;
- Optimism -> Ok;

Tested networks - Transactions:
- Ethereum -> Ok;
- Goerli -> Ok;
- Sepolia -> Failed. The transaction occurs successfully, but viem doesn't find the transaction hash, invoking an error toast, when actually the transaction goes fine