### PR TITLE
[Pool Simulator] Refactor Spot Price

### DIFF
--- a/apps/balancer-tools/src/app/poolsimulator/(components)/PoolTypeChangeConfirmation.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/PoolTypeChangeConfirmation.tsx
@@ -15,16 +15,15 @@ export function PoolTypeChangeConfirmation({
         <span>You are about to change the pool type to {selectedType}</span>
         <span>This action will reset all the parameters.</span>
       </div>
-      <div className="flex gap-x-4 py-3">
-        <DialogClose>
-          <span className="bg-transparent text-slate9 border-slate9 hover:bg-slate2 hover:border-slate2 rounded-md py-3 px-5 text-center text-sm font-semibold border focus-visible:outline-blue7 focus-visible:outline-offset-2 disabled:opacity-40">
-            Cancel
-          </span>
+      <div className="flex gap-x-4 my-3">
+        <DialogClose className="bg-transparent text-slate9 border-slate9 hover:bg-slate2 hover:border-slate2 rounded-md py-3 px-5 text-center text-sm font-semibold border focus-visible:outline-blue7 focus-visible:outline-offset-2 disabled:opacity-40">
+          Cancel
         </DialogClose>
-        <DialogClose onClick={onConfirm}>
-          <span className="bg-blue9 text-slate12 hover:bg-blue10 border-blue9 rounded-md py-3 px-5 text-center text-sm font-semibold border focus-visible:outline-blue7 focus-visible:outline-offset-2 disabled:opacity-40">
-            Confirm
-          </span>
+        <DialogClose
+          onClick={onConfirm}
+          className="bg-blue9 text-slate12 hover:bg-blue10 border-blue9 rounded-md py-3 px-5 text-center text-sm font-semibold border focus-visible:outline-blue7 focus-visible:outline-offset-2 disabled:opacity-40"
+        >
+          Confirm
         </DialogClose>
       </div>
     </div>

--- a/packages/math-poolsimulator/src/gyro2/index.ts
+++ b/packages/math-poolsimulator/src/gyro2/index.ts
@@ -99,61 +99,11 @@ export class ExtendedGyro2
     return poolPairData;
   }
 
-  _calculateSpotPriceWithoutSwap(
-    balances: BigNumber[],
-    virtualParamIn: BigNumber,
-    virtualParamOut: BigNumber,
-    swapFee: BigNumber,
-  ): BigNumber {
-    const afterFeeMultiplier = ONE.sub(swapFee); // 1 - s
-    const virtIn = balances[0].add(virtualParamIn); // x + virtualParamX = x'
-    const virtOut = balances[1].add(virtualParamOut); // y + virtualParamY = y'
-
-    const numerator = virtIn;
-    const denominator = GyroHelpersSignedFixedPoint.mulDown(
-      afterFeeMultiplier,
-      virtOut,
-    );
-    const newSpotPrice = GyroHelpersSignedFixedPoint.divDown(
-      numerator,
-      denominator,
-    );
-
-    return newSpotPrice;
-  }
-
   _spotPrice(poolPairData: Gyro2PoolPairData): OldBigNumber {
-    try {
-      const balances = [poolPairData.balanceIn, poolPairData.balanceOut];
-      const normalizedBalances = GyroHelpers._normalizeBalances(balances, [
-        poolPairData.decimalsIn,
-        poolPairData.decimalsOut,
-      ]);
-      const invariant = Gyro2Maths._calculateInvariant(
-        normalizedBalances,
-        poolPairData.sqrtAlpha,
-        poolPairData.sqrtBeta,
-      );
-
-      const [virtualParamIn, virtualParamOut] = Gyro2Maths._findVirtualParams(
-        invariant,
-        poolPairData.sqrtAlpha,
-        poolPairData.sqrtBeta,
-      );
-
-      // Here you can calculate the spot price based on the current state of the pool
-      // without performing any swaps.
-      const spotPrice = this._calculateSpotPriceWithoutSwap(
-        normalizedBalances,
-        virtualParamIn,
-        virtualParamOut,
-        poolPairData.swapFee,
-      );
-
-      return bnum(formatFixed(spotPrice, 18));
-    } catch (error) {
-      return bnum(0);
-    }
+    return this._spotPriceAfterSwapExactTokenInForTokenOut(
+      poolPairData,
+      bnum(0),
+    );
   }
   _firstGuessOfTokenInForExactSpotPriceAfterSwap(
     poolPairData: Gyro2PoolPairData,

--- a/packages/math-poolsimulator/src/metastable/index.ts
+++ b/packages/math-poolsimulator/src/metastable/index.ts
@@ -2,12 +2,10 @@ import {
   bnum,
   MetaStablePool,
   OldBigNumber,
-  StableMaths,
   SubgraphPoolBase,
   SubgraphToken,
-  ZERO,
 } from "@balancer-labs/sor";
-import { BigNumber, formatFixed, parseFixed } from "@ethersproject/bignumber";
+import { formatFixed, parseFixed } from "@ethersproject/bignumber";
 import { WeiPerEther as EONE } from "@ethersproject/constants";
 
 import { IAMMFunctionality } from "../types";
@@ -111,77 +109,11 @@ export class ExtendedMetaStableMath
     return poolPairData;
   }
 
-  _poolDerivatives(
-    A: BigNumber,
-    balances: OldBigNumber[],
-    tokenIndexIn: number,
-    tokenIndexOut: number,
-    is_first_derivative: boolean,
-    wrt_out: boolean,
-  ): OldBigNumber {
-    // This function was copied from @balancer/sor package, since was not exported
-    const totalCoins = balances.length;
-    const D = StableMaths._invariant(A, balances);
-    let S = ZERO;
-    for (let i = 0; i < totalCoins; i++) {
-      if (i != tokenIndexIn && i != tokenIndexOut) {
-        S = S.plus(balances[i]);
-      }
-    }
-    const x = balances[tokenIndexIn];
-    const y = balances[tokenIndexOut];
-    // A is passed as an ethers bignumber while maths uses bignumber.js
-    const AAdjusted = bnum(formatFixed(A, 3));
-    const a = AAdjusted.times(totalCoins ** totalCoins); // = ATimesNpowN
-    const b = S.minus(D).times(a).plus(D);
-    const twoaxy = bnum(2).times(a).times(x).times(y);
-    const partial_x = twoaxy.plus(a.times(y).times(y)).plus(b.times(y));
-    const partial_y = twoaxy.plus(a.times(x).times(x)).plus(b.times(x));
-    let ans;
-    if (is_first_derivative) {
-      ans = partial_x.div(partial_y);
-    } else {
-      const partial_xx = bnum(2).times(a).times(y);
-      const partial_yy = bnum(2).times(a).times(x);
-      const partial_xy = partial_xx.plus(partial_yy).plus(b);
-      const numerator = bnum(2)
-        .times(partial_x)
-        .times(partial_y)
-        .times(partial_xy)
-        .minus(partial_xx.times(partial_y.pow(2)))
-        .minus(partial_yy.times(partial_x.pow(2)));
-      const denominator = partial_x.pow(2).times(partial_y);
-      ans = numerator.div(denominator);
-      if (wrt_out) {
-        ans = ans.times(partial_y).div(partial_x);
-      }
-    }
-    return ans;
-  }
-
   _spotPrice(poolPairData: MetaStablePoolPairData): OldBigNumber {
-    // This function was developed based on @balancer/sor package
-    const ONE = bnum(1);
-
-    const { amp, allBalances, tokenIndexIn, tokenIndexOut, swapFee } =
-      poolPairData;
-    const n = allBalances.length;
-    const A = amp.div(n ** (n - 1));
-    const ans = this._poolDerivatives(
-      A,
-      allBalances,
-      tokenIndexIn,
-      tokenIndexOut,
-      true,
-      false,
+    return this._spotPriceAfterSwapExactTokenInForTokenOut(
+      poolPairData,
+      bnum(0),
     );
-    const spotPriceWithoutRates = ONE.div(
-      ans.times(EONE.sub(swapFee).toString()).div(EONE.toString()),
-    );
-
-    const priceRateIn = bnum(formatFixed(poolPairData.tokenInPriceRate, 18));
-    const priceRateOut = bnum(formatFixed(poolPairData.tokenOutPriceRate, 18));
-    return spotPriceWithoutRates.times(priceRateOut).div(priceRateIn);
   }
 
   _firstGuessOfTokenInForExactSpotPriceAfterSwap(


### PR DESCRIPTION
We noticed on #188 that `_spotPriceAfterSwapExactTokenInForTokenOut(poolPairData, bnum(0))` might have the same result as our ` _spotPrice()`. 

We tested, both on test and on dev, and the results were the same. Therefore, this a PR that uses directly `_spotPriceAfterSwapExactTokenInForTokenOut()` from SOR to define ` _spotPrice()`.

This PR also fix the outline of `PoolTypeChangeConfirmation` buttons