### PR TITLE
[APR] add pool pct votes to pool/{id}/round/{number}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 .vscode
 # Local Netlify folder
 .netlify
+.vercel

--- a/apps/balancer-tools/package.json
+++ b/apps/balancer-tools/package.json
@@ -50,7 +50,7 @@
     "inputmask": "^5.0.8",
     "lodash": "^4.17.21",
     "lodash.merge": "^4.6.2",
-    "next": "^13.4.13",
+    "next": "^13.3.4",
     "plotly.js": "^2.24.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/balancer-tools/src/app/apr/(components)/BALPrice.tsx
+++ b/apps/balancer-tools/src/app/apr/(components)/BALPrice.tsx
@@ -6,10 +6,11 @@ import { Round } from "../(utils)/rounds";
 export default async function BALPrice({
   roundId,
 }: {
-  roundId: string | string[];
+  roundId?: string | string[];
 }) {
   invariant(!Array.isArray(roundId), "roundId cannot be a list");
-  const round = Round.getRoundByNumber(roundId);
+
+  const round = roundId? Round.getRoundByNumber(roundId) : Round.currentRound();
 
   return <Price data={getBALPriceByRound(round)} />;
 }
@@ -24,10 +25,10 @@ export const Price = async ({
   return (
     <div>
       BAL price:{" "}
-      {price.toLocaleString("en-US", {
+      {price ? price.toLocaleString("en-US", {
         style: "currency",
         currency: "USD",
-      })}
+      }) : "error"}
     </div>
   );
 };

--- a/apps/balancer-tools/src/app/apr/(components)/BALPrice.tsx
+++ b/apps/balancer-tools/src/app/apr/(components)/BALPrice.tsx
@@ -10,7 +10,9 @@ export default async function BALPrice({
 }) {
   invariant(!Array.isArray(roundId), "roundId cannot be a list");
 
-  const round = roundId? Round.getRoundByNumber(roundId) : Round.currentRound();
+  const round = roundId
+    ? Round.getRoundByNumber(roundId)
+    : Round.currentRound();
 
   return <Price data={getBALPriceByRound(round)} />;
 }
@@ -25,10 +27,12 @@ export const Price = async ({
   return (
     <div>
       BAL price:{" "}
-      {price ? price.toLocaleString("en-US", {
-        style: "currency",
-        currency: "USD",
-      }) : "error"}
+      {price
+        ? price.toLocaleString("en-US", {
+            style: "currency",
+            currency: "USD",
+          })
+        : "error"}
     </div>
   );
 };

--- a/apps/balancer-tools/src/app/apr/(components)/PoolPctVotesInRound.tsx
+++ b/apps/balancer-tools/src/app/apr/(components)/PoolPctVotesInRound.tsx
@@ -14,7 +14,10 @@ export default async function PoolPctVotesInRound({
   invariant(!Array.isArray(roundId), "roundId cannot be a list");
   invariant(!Array.isArray(poolId), "poolId cannot be a list");
 
-  const gaugeData = await fetcher<DuneGaugeData[] | { error: string }>(`http://localhost:3000/apr/rounds/${roundId}`, {method: "GET"});
+  const gaugeData = await fetcher<DuneGaugeData[] | { error: string }>(
+    `http://localhost:3000/apr/rounds/${roundId}`,
+    { method: "GET" },
+  );
 
   if ("error" in gaugeData) {
     return <div>{gaugeData.error}</div>;
@@ -23,13 +26,22 @@ export default async function PoolPctVotesInRound({
   const pool = new Pool(poolId);
   const gaugeAddress = pool.gauge?.address;
 
-  const gauge = gaugeData.find((gauge) => gauge.symbol.toLowerCase() === gaugeAddress?.toLowerCase());
+  const gauge = gaugeData.find(
+    (gauge) => gauge.symbol.toLowerCase() === gaugeAddress?.toLowerCase(),
+  );
 
   if (!gauge?.pct_votes) {
-    return <div>Pool {poolId} (gauge {gaugeAddress}) had no votes in round {roundId}</div>
+    return (
+      <div>
+        Pool {poolId} (gauge {gaugeAddress}) had no votes in round {roundId}
+      </div>
+    );
   }
 
-  return <div>
-    {poolId} (gauge {gaugeAddress}) had {(gauge?.pct_votes * 100).toFixed(2)}% Voted in round {roundId}
-  </div>
+  return (
+    <div>
+      {poolId} (gauge {gaugeAddress}) had {(gauge?.pct_votes * 100).toFixed(2)}%
+      Voted in round {roundId}
+    </div>
+  );
 }

--- a/apps/balancer-tools/src/app/apr/(components)/PoolPctVotesInRound.tsx
+++ b/apps/balancer-tools/src/app/apr/(components)/PoolPctVotesInRound.tsx
@@ -23,13 +23,13 @@ export default async function PoolPctVotesInRound({
   const pool = new Pool(poolId);
   const gaugeAddress = pool.gauge?.address;
 
-  const gauge = gaugeData.find((gauge) => gauge.symbol === gaugeAddress);
+  const gauge = gaugeData.find((gauge) => gauge.symbol.toLowerCase() === gaugeAddress?.toLowerCase());
 
   if (!gauge?.pct_votes) {
     return <div>Pool {poolId} (gauge {gaugeAddress}) had no votes in round {roundId}</div>
   }
 
   return <div>
-    {poolId} \(gauge {gaugeAddress}\) had {(gauge?.pct_votes * 100).toFixed(2)}% Voted in round {roundId}
+    {poolId} (gauge {gaugeAddress}) had {(gauge?.pct_votes * 100).toFixed(2)}% Voted in round {roundId}
   </div>
 }

--- a/apps/balancer-tools/src/app/apr/(components)/PoolPctVotesInRound.tsx
+++ b/apps/balancer-tools/src/app/apr/(components)/PoolPctVotesInRound.tsx
@@ -3,6 +3,7 @@ import invariant from "tiny-invariant";
 import { Pool } from "#/lib/balancer/gauges";
 import { DuneGaugeData } from "#/lib/dune";
 import { fetcher } from "#/utils/fetcher";
+import getBaseURL from "#/utils/getBaseURL";
 
 export default async function PoolPctVotesInRound({
   roundId,
@@ -15,7 +16,7 @@ export default async function PoolPctVotesInRound({
   invariant(!Array.isArray(poolId), "poolId cannot be a list");
 
   const gaugeData = await fetcher<DuneGaugeData[] | { error: string }>(
-    `http://localhost:3000/apr/rounds/${roundId}`,
+    `${getBaseURL()}/apr/rounds/${roundId}`,
     { method: "GET" },
   );
 

--- a/apps/balancer-tools/src/app/apr/(components)/PoolPctVotesInRound.tsx
+++ b/apps/balancer-tools/src/app/apr/(components)/PoolPctVotesInRound.tsx
@@ -1,0 +1,35 @@
+import invariant from "tiny-invariant";
+
+import { Pool } from "#/lib/balancer/gauges";
+import { DuneGaugeData } from "#/lib/dune";
+import { fetcher } from "#/utils/fetcher";
+
+export default async function PoolPctVotesInRound({
+  roundId,
+  poolId,
+}: {
+  roundId?: string | string[];
+  poolId: string | string[];
+}) {
+  invariant(!Array.isArray(roundId), "roundId cannot be a list");
+  invariant(!Array.isArray(poolId), "poolId cannot be a list");
+
+  const gaugeData = await fetcher<DuneGaugeData[] | { error: string }>(`http://localhost:3000/apr/rounds/${roundId}`, {method: "GET"});
+
+  if ("error" in gaugeData) {
+    return <div>{gaugeData.error}</div>;
+  }
+
+  const pool = new Pool(poolId);
+  const gaugeAddress = pool.gauge?.address;
+
+  const gauge = gaugeData.find((gauge) => gauge.symbol === gaugeAddress);
+
+  if (!gauge?.pct_votes) {
+    return <div>Pool {poolId} (gauge {gaugeAddress}) had no votes in round {roundId}</div>
+  }
+
+  return <div>
+    {poolId} \(gauge {gaugeAddress}\) had {(gauge?.pct_votes * 100).toFixed(2)}% Voted in round {roundId}
+  </div>
+}

--- a/apps/balancer-tools/src/app/apr/(utils)/rounds.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/rounds.ts
@@ -6,10 +6,10 @@ export class Round {
   value: string;
   activeRound: boolean;
 
-  constructor(endDate: Date, roundNumber: number, active: boolean) {
+  constructor(endDate: Date, roundNumber: number) {
     this.endDate = endDate;
     this.value = String(roundNumber);
-    this.activeRound = active;
+    this.activeRound = endDate.getTime() > Date.now();
   }
 
   get label(): string {
@@ -38,8 +38,13 @@ export class Round {
       const endDate = new Date(
         Round.FIRST_ROUND_END_DATE.getTime() + i * Round.ONE_WEEK_IN_MS,
       );
-      return new Round(endDate, i + 1, i === roundsCount - 1);
+      return new Round(endDate, i + 1);
     }).reverse();
+  }
+
+  static currentRound(): Round {
+    const allRounds = Round.getAllRounds();
+    return allRounds.find((round) => round.activeRound)!;
   }
 
   static getRoundByNumber(roundNumber: number | string): Round {

--- a/apps/balancer-tools/src/app/apr/layout.tsx
+++ b/apps/balancer-tools/src/app/apr/layout.tsx
@@ -18,7 +18,7 @@ const LAST_ROUND_ID = ALL_ROUNDS[0].value;
 export default function Layout({ children }: React.PropsWithChildren) {
   const router = useRouter();
 
-  const { roundId, poolId } = useParams();
+  const { roundId, poolId, network } = useParams();
   const form = useForm<PoolAttribute>();
   const { setValue } = form;
 
@@ -26,7 +26,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
   invariant(!Array.isArray(poolId), "poolId cannot be a list");
 
   React.useEffect(() => {
-    if (!roundId || roundId === "current") {
+    if (!poolId && (!roundId || roundId === "current")) {
       router.push(`/apr/round/${LAST_ROUND_ID}`);
     }
   }, [roundId]);
@@ -47,7 +47,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
             defaultValuePool={poolId}
             onSubmit={(value) => {
               router.push(
-                `/apr/pool/${value.network}/${value.poolId}/round/${roundId}`,
+                `/apr/pool/${value.network}/${value.poolId}`,
               );
               setValue("poolId", value.poolId);
             }}
@@ -70,7 +70,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
               <Select
                 value={roundId ?? ""}
                 onValueChange={(value) => {
-                  router.push(!poolId ? `/apr/round/${value}` : `${value}`);
+                  router.push(!poolId ? `/apr/round/${value}` : `/apr/pool/${network}/${poolId}/round/${value}`);
                 }}
                 className="w-full"
               >

--- a/apps/balancer-tools/src/app/apr/layout.tsx
+++ b/apps/balancer-tools/src/app/apr/layout.tsx
@@ -46,9 +46,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
             form={form}
             defaultValuePool={poolId}
             onSubmit={(value) => {
-              router.push(
-                `/apr/pool/${value.network}/${value.poolId}`,
-              );
+              router.push(`/apr/pool/${value.network}/${value.poolId}`);
               setValue("poolId", value.poolId);
             }}
           >
@@ -70,7 +68,11 @@ export default function Layout({ children }: React.PropsWithChildren) {
               <Select
                 value={roundId ?? ""}
                 onValueChange={(value) => {
-                  router.push(!poolId ? `/apr/round/${value}` : `/apr/pool/${network}/${poolId}/round/${value}`);
+                  router.push(
+                    !poolId
+                      ? `/apr/round/${value}`
+                      : `/apr/pool/${network}/${poolId}/round/${value}`,
+                  );
                 }}
                 className="w-full"
               >

--- a/apps/balancer-tools/src/app/apr/mock_apis.tsx
+++ b/apps/balancer-tools/src/app/apr/mock_apis.tsx
@@ -2,6 +2,8 @@ export const voteGaugeByID = [
   {
     pct_votes: 0.24118497395666047,
     symbol: "0x9ab7b0c7b154f626451c9e8a68dc04f58fb6e5ce",
+    // poolID: 0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019
+    // but that pool can't be found on the search
     votes: 119811.6992448796,
   },
   {

--- a/apps/balancer-tools/src/app/apr/mock_apis.tsx
+++ b/apps/balancer-tools/src/app/apr/mock_apis.tsx
@@ -2,8 +2,6 @@ export const voteGaugeByID = [
   {
     pct_votes: 0.24118497395666047,
     symbol: "0x9ab7b0c7b154f626451c9e8a68dc04f58fb6e5ce",
-    // poolID: 0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019
-    // but that pool can't be found on the search
     votes: 119811.6992448796,
   },
   {

--- a/apps/balancer-tools/src/app/apr/pool/[network]/[poolId]/page.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/[network]/[poolId]/page.tsx
@@ -1,5 +1,6 @@
-import BALPrice from "#/app/apr/(components)/BALPrice";
 import { Suspense } from "react";
+
+import BALPrice from "#/app/apr/(components)/BALPrice";
 
 export default function Page({
   params,
@@ -10,12 +11,12 @@ export default function Page({
 
   return (
     <>
-    <div className="flex h-full w-full flex-col justify-center rounded-3xl">
-      hello from pool {poolId} in network {network}
-    </div>
-        <Suspense fallback={"Loading..."}>
-          <BALPrice  />
-        </Suspense>
-        </>
+      <div className="flex h-full w-full flex-col justify-center rounded-3xl">
+        hello from pool {poolId} in network {network}
+      </div>
+      <Suspense fallback={"Loading..."}>
+        <BALPrice />
+      </Suspense>
+    </>
   );
 }

--- a/apps/balancer-tools/src/app/apr/pool/[network]/[poolId]/page.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/[network]/[poolId]/page.tsx
@@ -1,3 +1,6 @@
+import BALPrice from "#/app/apr/(components)/BALPrice";
+import { Suspense } from "react";
+
 export default function Page({
   params,
 }: {
@@ -6,8 +9,13 @@ export default function Page({
   const { network, poolId } = params;
 
   return (
+    <>
     <div className="flex h-full w-full flex-col justify-center rounded-3xl">
       hello from pool {poolId} in network {network}
     </div>
+        <Suspense fallback={"Loading..."}>
+          <BALPrice  />
+        </Suspense>
+        </>
   );
 }

--- a/apps/balancer-tools/src/app/apr/pool/[network]/[poolId]/round/[roundId]/page.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/[network]/[poolId]/round/[roundId]/page.tsx
@@ -12,8 +12,7 @@ export default async function Page({
 
   return (
     <div className="flex h-full w-full flex-col justify-center rounded-3xl text-white">
-      hello from pool {poolId} in network {network} for round {roundId}. Pool share in round {roundId} is
-
+      hello from pool {poolId} in network {network} for round {roundId}.
       <Suspense fallback={"Loading..."}>
         <PoolPctVotesInRound poolId={poolId} roundId={roundId} />
       </Suspense>

--- a/apps/balancer-tools/src/app/apr/pool/[network]/[poolId]/round/[roundId]/page.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/[network]/[poolId]/round/[roundId]/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 
 import BALPrice from "#/app/apr/(components)/BALPrice";
+import PoolPctVotesInRound from "#/app/apr/(components)/PoolPctVotesInRound";
 
 export default async function Page({
   params,
@@ -11,7 +12,11 @@ export default async function Page({
 
   return (
     <div className="flex h-full w-full flex-col justify-center rounded-3xl text-white">
-      hello from pool {poolId} in network {network} for round {roundId}
+      hello from pool {poolId} in network {network} for round {roundId}. Pool share in round {roundId} is
+
+      <Suspense fallback={"Loading..."}>
+        <PoolPctVotesInRound poolId={poolId} roundId={roundId} />
+      </Suspense>
       <Suspense fallback={"Loading..."}>
         <BALPrice roundId={roundId} />
       </Suspense>

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
@@ -1,12 +1,13 @@
+import { networkFor } from "@bleu-balancer-tools/utils";
 import { ChevronRightIcon } from "@radix-ui/react-icons";
+import Link from "next/link";
+import { Suspense } from "react";
 
 import { Gauge } from "#/lib/balancer/gauges";
 import { DuneGaugeData } from "#/lib/dune";
 import { fetcher } from "#/utils/fetcher";
 import { formatNumber } from "#/utils/formatNumber";
-import { networkFor } from "@bleu-balancer-tools/utils";
-import Link from "next/link";
-import { Suspense } from "react";
+
 import BALPrice from "../../(components)/BALPrice";
 
 function PoolCard({
@@ -14,51 +15,48 @@ function PoolCard({
 }: {
   data: DuneGaugeData;
 }) {
-  const gauge = new Gauge(symbol)
+  const gauge = new Gauge(symbol);
   const poolId = gauge.pool.id;
 
   return (
     <Link href={`/apr/pool/${networkFor(gauge.network)}/${gauge.pool.id}`}>
-    <div
-      className="flex justify-between border border-gray-400 lg:border-gray-400 bg-blue3 rounded p-4 cursor-pointer"
-    >
-      <div className="">
-        <div className="flex justify-between">
-          <div className="text-white font-bold text-lg mb-2">{poolId}</div>
-        </div>
-        <div className="flex items-center">
-          <div className="text-sm">
-            <p className="text-white leading-none mb-1">
-              {(pctVotes * 100).toFixed(2)}% Voted
-            </p>
-            <p className="text-white text-xs">{formatNumber(votes)} Votes</p>
-            <Suspense fallback={"Loading..."}>
-              <BALPrice  />
-            </Suspense>
+      <div className="flex justify-between border border-gray-400 lg:border-gray-400 bg-blue3 rounded p-4 cursor-pointer">
+        <div className="">
+          <div className="flex justify-between">
+            <div className="text-white font-bold text-lg mb-2">{poolId}</div>
+          </div>
+          <div className="flex items-center">
+            <div className="text-sm">
+              <p className="text-white leading-none mb-1">
+                {(pctVotes * 100).toFixed(2)}% Voted
+              </p>
+              <p className="text-white text-xs">{formatNumber(votes)} Votes</p>
+              <Suspense fallback={"Loading..."}>
+                <BALPrice />
+              </Suspense>
+            </div>
           </div>
         </div>
+        <div className="text-white flex flex-col justify-center">
+          <ChevronRightIcon />
+        </div>
       </div>
-      <div className="text-white flex flex-col justify-center">
-        <ChevronRightIcon />
-      </div>
-    </div>
     </Link>
   );
 }
 
-export default async function PoolsCards({
-  roundId,
-}: {
-  roundId:string
-}) {
-  const poolsData = await fetcher<DuneGaugeData[] | { error: string }>(`http://localhost:3000/apr/rounds/${roundId}`, { cache: "force-cache"});
+export default async function PoolsCards({ roundId }: { roundId: string }) {
+  const poolsData = await fetcher<DuneGaugeData[] | { error: string }>(
+    `http://localhost:3000/apr/rounds/${roundId}`,
+    { cache: "force-cache" },
+  );
 
   if ("error" in poolsData) throw new Error(poolsData.error);
 
   return (
     <div className="space-y-6 w-full">
-      {poolsData.slice(0,1).map((data) => (
-        <PoolCard data={data} key={data.symbol}/>
+      {poolsData.slice(0, 1).map((data) => (
+        <PoolCard data={data} key={data.symbol} />
       ))}
     </div>
   );

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
@@ -1,6 +1,5 @@
 import { networkFor } from "@bleu-balancer-tools/utils";
 import { ChevronRightIcon } from "@radix-ui/react-icons";
-import { headers } from "next/headers";
 import Link from "next/link";
 import { Suspense } from "react";
 
@@ -8,6 +7,7 @@ import { Gauge } from "#/lib/balancer/gauges";
 import { DuneGaugeData } from "#/lib/dune";
 import { fetcher } from "#/utils/fetcher";
 import { formatNumber } from "#/utils/formatNumber";
+import getBaseURL from "#/utils/getBaseURL";
 
 import BALPrice from "../../(components)/BALPrice";
 
@@ -47,14 +47,6 @@ function PoolCard({
     </Link>
   );
 }
-
-const getBaseURL = () => {
-  const headersList = headers();
-  const host = headersList.get("host") || "localhost:3000";
-  const protocol = headersList.get("x-forwarded-proto") || "http";
-
-  return `${protocol}://${host}`;
-};
 
 export default async function PoolsCards({ roundId }: { roundId: string }) {
   const poolsData = await fetcher<DuneGaugeData[] | { error: string }>(

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
@@ -1,5 +1,6 @@
 import { networkFor } from "@bleu-balancer-tools/utils";
 import { ChevronRightIcon } from "@radix-ui/react-icons";
+import { headers } from "next/headers";
 import Link from "next/link";
 import { Suspense } from "react";
 
@@ -12,10 +13,10 @@ import BALPrice from "../../(components)/BALPrice";
 
 function PoolCard({
   data: { symbol, pct_votes: pctVotes, votes },
-  roundId
+  roundId,
 }: {
   data: DuneGaugeData;
-  roundId?: string
+  roundId?: string;
 }) {
   const gauge = new Gauge(symbol);
   const poolId = gauge.pool.id;
@@ -34,7 +35,7 @@ function PoolCard({
               </p>
               <p className="text-white text-xs">{formatNumber(votes)} Votes</p>
               <Suspense fallback={"Loading..."}>
-                <BALPrice roundId={roundId}/>
+                <BALPrice roundId={roundId} />
               </Suspense>
             </div>
           </div>
@@ -47,9 +48,17 @@ function PoolCard({
   );
 }
 
+const getBaseURL = () => {
+  const headersList = headers();
+  const host = headersList.get("host") || "localhost:3000";
+  const protocol = headersList.get("x-forwarded-proto") || "http";
+
+  return `${protocol}://${host}`;
+};
+
 export default async function PoolsCards({ roundId }: { roundId: string }) {
   const poolsData = await fetcher<DuneGaugeData[] | { error: string }>(
-    `http://localhost:3000/apr/rounds/${roundId}`,
+    `${getBaseURL()}/apr/rounds/${roundId}`,
     { cache: "force-cache" },
   );
 

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
@@ -1,29 +1,40 @@
 import { ChevronRightIcon } from "@radix-ui/react-icons";
 
-import { DunePoolData } from "#/lib/dune";
+import { DuneGaugeData } from "#/lib/dune";
 import { fetcher } from "#/utils/fetcher";
 import { formatNumber } from "#/utils/formatNumber";
+import { Gauge } from "#/lib/balancer/gauges";
+import Link from "next/link";
+import { networkFor } from "@bleu-balancer-tools/utils";
+import { Suspense } from "react";
+import BALPrice from "../../(components)/BALPrice";
 
 function PoolCard({
   data: { symbol, pct_votes: pctVotes, votes },
 }: {
-  data: DunePoolData;
+  data: DuneGaugeData;
 }) {
+  const gauge = new Gauge(symbol)
+  const poolId = gauge.pool.id;
+
   return (
+    <Link href={`/apr/pool/${networkFor(gauge.network)}/${gauge.pool.id}`}>
     <div
-      key={symbol}
       className="flex justify-between border border-gray-400 lg:border-gray-400 bg-blue3 rounded p-4 cursor-pointer"
     >
       <div className="">
         <div className="flex justify-between">
-          <div className="text-white font-bold text-xl mb-2">{symbol}</div>
+          <div className="text-white font-bold text-lg mb-2">{poolId}</div>
         </div>
         <div className="flex items-center">
           <div className="text-sm">
             <p className="text-white leading-none mb-1">
-              {pctVotes.toFixed(2)}% Voted
+              {(pctVotes * 100).toFixed(2)}% Voted
             </p>
             <p className="text-white text-xs">{formatNumber(votes)} Votes</p>
+            <Suspense fallback={"Loading..."}>
+              <BALPrice  />
+            </Suspense>
           </div>
         </div>
       </div>
@@ -31,13 +42,14 @@ function PoolCard({
         <ChevronRightIcon />
       </div>
     </div>
+    </Link>
   );
 }
 
 export default async function PoolsCards({
   data,
 }: {
-  data: ReturnType<typeof fetcher<DunePoolData[] | { error: string }>>;
+  data: ReturnType<typeof fetcher<DuneGaugeData[] | { error: string }>>;
 }) {
   const poolsData = await data;
 
@@ -45,8 +57,8 @@ export default async function PoolsCards({
 
   return (
     <div className="space-y-6 w-full">
-      {poolsData.map((poolData) => (
-        <PoolCard data={poolData} />
+      {poolsData.slice(0,1).map((data) => (
+        <PoolCard data={data} key={data.symbol}/>
       ))}
     </div>
   );

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
@@ -1,11 +1,11 @@
 import { ChevronRightIcon } from "@radix-ui/react-icons";
 
+import { Gauge } from "#/lib/balancer/gauges";
 import { DuneGaugeData } from "#/lib/dune";
 import { fetcher } from "#/utils/fetcher";
 import { formatNumber } from "#/utils/formatNumber";
-import { Gauge } from "#/lib/balancer/gauges";
-import Link from "next/link";
 import { networkFor } from "@bleu-balancer-tools/utils";
+import Link from "next/link";
 import { Suspense } from "react";
 import BALPrice from "../../(components)/BALPrice";
 
@@ -47,11 +47,11 @@ function PoolCard({
 }
 
 export default async function PoolsCards({
-  data,
+  roundId,
 }: {
-  data: ReturnType<typeof fetcher<DuneGaugeData[] | { error: string }>>;
+  roundId:string
 }) {
-  const poolsData = await data;
+  const poolsData = await fetcher<DuneGaugeData[] | { error: string }>(`http://localhost:3000/apr/rounds/${roundId}`, { cache: "force-cache"});
 
   if ("error" in poolsData) throw new Error(poolsData.error);
 

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolsCards.tsx
@@ -12,8 +12,10 @@ import BALPrice from "../../(components)/BALPrice";
 
 function PoolCard({
   data: { symbol, pct_votes: pctVotes, votes },
+  roundId
 }: {
   data: DuneGaugeData;
+  roundId?: string
 }) {
   const gauge = new Gauge(symbol);
   const poolId = gauge.pool.id;
@@ -32,7 +34,7 @@ function PoolCard({
               </p>
               <p className="text-white text-xs">{formatNumber(votes)} Votes</p>
               <Suspense fallback={"Loading..."}>
-                <BALPrice />
+                <BALPrice roundId={roundId}/>
               </Suspense>
             </div>
           </div>
@@ -56,7 +58,7 @@ export default async function PoolsCards({ roundId }: { roundId: string }) {
   return (
     <div className="space-y-6 w-full">
       {poolsData.slice(0, 1).map((data) => (
-        <PoolCard data={data} key={data.symbol} />
+        <PoolCard data={data} roundId={roundId} key={data.symbol} />
       ))}
     </div>
   );

--- a/apps/balancer-tools/src/app/apr/round/[roundId]/page.tsx
+++ b/apps/balancer-tools/src/app/apr/round/[roundId]/page.tsx
@@ -1,9 +1,6 @@
-"use client";
-
 import { Suspense } from "react";
 
 import Loading from "#/app/metadata/[network]/pool/[poolId]/loading";
-import { fetcher } from "#/utils/fetcher";
 
 import PoolsCards from "../(components)/PoolsCards";
 
@@ -20,7 +17,7 @@ export default function Page({
         </div>
       }
     >
-      <PoolsCards data={fetcher(`http://localhost:3000/apr/rounds/${roundId}`)} />
+      <PoolsCards roundId={roundId} />
     </Suspense>
   );
 }

--- a/apps/balancer-tools/src/app/apr/round/[roundId]/page.tsx
+++ b/apps/balancer-tools/src/app/apr/round/[roundId]/page.tsx
@@ -20,7 +20,7 @@ export default function Page({
         </div>
       }
     >
-      <PoolsCards data={fetcher(`/apr/rounds/${roundId}`)} />
+      <PoolsCards data={fetcher(`http://localhost:3000/apr/rounds/${roundId}`)} />
     </Suspense>
   );
 }

--- a/apps/balancer-tools/src/components/SearchPoolForm/filterPoolInput.test.ts
+++ b/apps/balancer-tools/src/components/SearchPoolForm/filterPoolInput.test.ts
@@ -1,0 +1,89 @@
+import filterPoolInput, { Pool } from "./filterPoolInput";
+
+describe("filterPoolInput function", () => {
+  const mockPools: Pool[] = [
+    {
+      id: "0x0017c363b29d8f86d82e9681552685f68f34b7e4000200000000000000000209",
+      address: "0x0017c363b29d8f86d82e9681552685f68f34b7e4",
+      name: "Skorge Copper LBP",
+      poolType: "LiquidityBootstrapping",
+      symbol: "Skorge_LBP",
+      totalLiquidity: "0.000001000000025784848219663865585262822",
+      tokens: [
+        {
+          symbol: "USDC",
+        },
+        {
+          symbol: "Skorge",
+        },
+      ],
+    },
+    {
+      id: "0x0022b6e4ff3ddbf0c36c7c6c7c7f3062f36be5f8000200000000000000000330",
+      address: "0x0022b6e4ff3ddbf0c36c7c6c7c7f3062f36be5f8",
+      name: "SHHH Copper LBP",
+      poolType: "LiquidityBootstrapping",
+      symbol: "SHHH_LBP",
+      totalLiquidity: "0.000001000000045104426850456188493054481",
+      tokens: [
+        {
+          symbol: "USDC",
+        },
+        {
+          symbol: "SHHH",
+        },
+      ],
+    },
+    {
+      id: "0x00612eb4f312eb6ace7acc8781196601078ae3390002000000000000000005a2",
+      address: "0x00612eb4f312eb6ace7acc8781196601078ae339",
+      name: "20GHO-80PSP",
+      poolType: "Weighted",
+      symbol: "20GHO-80PSP",
+      totalLiquidity: "935.776172612115125739114553555563",
+      tokens: [
+        {
+          symbol: "GHO",
+        },
+        {
+          symbol: "PSP",
+        },
+      ],
+    },
+  ];
+
+  it("should return true when poolSearchQuery is empty", () => {
+    const pool = mockPools[0];
+    const result = filterPoolInput({ poolSearchQuery: "", pool });
+    expect(result).toBe(true);
+  });
+
+  it("should return false when pool is not provided", () => {
+    const result = filterPoolInput({ poolSearchQuery: "Skorge" });
+    expect(result).toBe(false);
+  });
+
+  it("should filter by token symbol", () => {
+    const USDCvSHHHPool = mockPools[1];
+    const result = filterPoolInput({
+      poolSearchQuery: "USDC",
+      pool: USDCvSHHHPool,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should filter by pool name", () => {
+    const pool = mockPools[0];
+    const result = filterPoolInput({
+      poolSearchQuery: "Skorge Copper LBP",
+      pool,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return false for non-matching queries", () => {
+    const pool = mockPools[0];
+    const result = filterPoolInput({ poolSearchQuery: "NonExistent", pool });
+    expect(result).toBe(false);
+  });
+});

--- a/apps/balancer-tools/src/components/SearchPoolForm/filterPoolInput.ts
+++ b/apps/balancer-tools/src/components/SearchPoolForm/filterPoolInput.ts
@@ -1,0 +1,63 @@
+
+import { PoolsWherePoolTypeQuery } from "@bleu-balancer-tools/gql/src/balancer/__generated__/Ethereum";
+
+import { ArrElement, GetDeepProp } from "#/utils/getTypes";
+
+
+function escapeRegExp(string: string): string {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  type Pool = ArrElement<GetDeepProp<PoolsWherePoolTypeQuery, "pools">>
+
+  function isValuePresent(value: string | Pool["tokens"], regex: RegExp): boolean {
+    if (typeof value === "string" && regex.test(value)) {
+        return true;
+    }
+
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            for (const subValue of Object.values(item)) {
+                if (typeof subValue === "string" && regex.test(subValue)) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+  }
+
+  interface FilterPoolInputProps {
+    poolSearchQuery: string;
+    pool?: Pool;
+  }
+
+export default  function filterPoolInput({
+    poolSearchQuery,
+    pool
+  }: FilterPoolInputProps): boolean {
+    if (!poolSearchQuery) return true;
+    if (!pool) return false;
+
+    const searchValues = poolSearchQuery.split(/\s+/);
+
+    for (const searchValue of searchValues) {
+        const escapedQuery = escapeRegExp(searchValue.trim());
+        const regex = new RegExp(escapedQuery, "i");
+        let valueMatched = false;
+
+        for (const value of Object.values(pool)) {
+            if (isValuePresent(value, regex)) {
+                valueMatched = true;
+                break;
+            }
+        }
+
+        if (!valueMatched) {
+            return false;
+        }
+    }
+
+    return true;
+  }

--- a/apps/balancer-tools/src/components/SearchPoolForm/filterPoolInput.ts
+++ b/apps/balancer-tools/src/components/SearchPoolForm/filterPoolInput.ts
@@ -2,32 +2,13 @@ import { PoolsWherePoolTypeQuery } from "@bleu-balancer-tools/gql/src/balancer/_
 
 import { ArrElement, GetDeepProp } from "#/utils/getTypes";
 
+import { isValuePresent } from "./isValuePresent";
+
 function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-type Pool = ArrElement<GetDeepProp<PoolsWherePoolTypeQuery, "pools">>;
-
-function isValuePresent(
-  value: string | Pool["tokens"],
-  regex: RegExp,
-): boolean {
-  if (typeof value === "string" && regex.test(value)) {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      for (const subValue of Object.values(item)) {
-        if (typeof subValue === "string" && regex.test(subValue)) {
-          return true;
-        }
-      }
-    }
-  }
-
-  return false;
-}
+export type Pool = ArrElement<GetDeepProp<PoolsWherePoolTypeQuery, "pools">>;
 
 interface FilterPoolInputProps {
   poolSearchQuery: string;

--- a/apps/balancer-tools/src/components/SearchPoolForm/filterPoolInput.ts
+++ b/apps/balancer-tools/src/components/SearchPoolForm/filterPoolInput.ts
@@ -1,63 +1,64 @@
-
 import { PoolsWherePoolTypeQuery } from "@bleu-balancer-tools/gql/src/balancer/__generated__/Ethereum";
 
 import { ArrElement, GetDeepProp } from "#/utils/getTypes";
 
-
 function escapeRegExp(string: string): string {
-    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
-  type Pool = ArrElement<GetDeepProp<PoolsWherePoolTypeQuery, "pools">>
+type Pool = ArrElement<GetDeepProp<PoolsWherePoolTypeQuery, "pools">>;
 
-  function isValuePresent(value: string | Pool["tokens"], regex: RegExp): boolean {
-    if (typeof value === "string" && regex.test(value)) {
-        return true;
-    }
-
-    if (Array.isArray(value)) {
-        for (const item of value) {
-            for (const subValue of Object.values(item)) {
-                if (typeof subValue === "string" && regex.test(subValue)) {
-                    return true;
-                }
-            }
-        }
-    }
-
-    return false;
-  }
-
-  interface FilterPoolInputProps {
-    poolSearchQuery: string;
-    pool?: Pool;
-  }
-
-export default  function filterPoolInput({
-    poolSearchQuery,
-    pool
-  }: FilterPoolInputProps): boolean {
-    if (!poolSearchQuery) return true;
-    if (!pool) return false;
-
-    const searchValues = poolSearchQuery.split(/\s+/);
-
-    for (const searchValue of searchValues) {
-        const escapedQuery = escapeRegExp(searchValue.trim());
-        const regex = new RegExp(escapedQuery, "i");
-        let valueMatched = false;
-
-        for (const value of Object.values(pool)) {
-            if (isValuePresent(value, regex)) {
-                valueMatched = true;
-                break;
-            }
-        }
-
-        if (!valueMatched) {
-            return false;
-        }
-    }
-
+function isValuePresent(
+  value: string | Pool["tokens"],
+  regex: RegExp,
+): boolean {
+  if (typeof value === "string" && regex.test(value)) {
     return true;
   }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      for (const subValue of Object.values(item)) {
+        if (typeof subValue === "string" && regex.test(subValue)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+interface FilterPoolInputProps {
+  poolSearchQuery: string;
+  pool?: Pool;
+}
+
+export default function filterPoolInput({
+  poolSearchQuery,
+  pool,
+}: FilterPoolInputProps): boolean {
+  if (!poolSearchQuery) return true;
+  if (!pool) return false;
+
+  const searchValues = poolSearchQuery.split(/\s+/);
+
+  for (const searchValue of searchValues) {
+    const escapedQuery = escapeRegExp(searchValue.trim());
+    const regex = new RegExp(escapedQuery, "i");
+    let valueMatched = false;
+
+    for (const value of Object.values(pool)) {
+      if (isValuePresent(value, regex)) {
+        valueMatched = true;
+        break;
+      }
+    }
+
+    if (!valueMatched) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
+++ b/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { PoolsWherePoolTypeQuery } from "@bleu-balancer-tools/gql/src/balancer/__generated__/Ethereum";
 import { ReactNode, useEffect, useLayoutEffect, useState } from "react";
-import { useForm, UseFormReturn } from "react-hook-form";
+import { useForm,UseFormReturn } from "react-hook-form";
 
 import Button from "#/components/Button";
 import { Input } from "#/components/Input";
 import { Select, SelectItem } from "#/components/Select";
 import { pools } from "#/lib/gql";
-import { ArrElement, GetDeepProp } from "#/utils/getTypes";
 import { truncateAddress } from "#/utils/truncate";
 
-import { Form, FormField, FormLabel } from "./ui/form";
+import { Form, FormField, FormLabel } from "../ui/form";
+import filterPoolInput from "./filterPoolInput";
 
 export interface PoolAttribute {
   poolId: string;
@@ -24,6 +23,7 @@ const inputTypenames = [
   { value: "42161", label: "Arbitrum" },
   { value: "5", label: "Goerli" },
 ];
+
 
 export function SearchPoolForm({
   close,
@@ -58,7 +58,8 @@ export function SearchPoolForm({
   const gqlVariables = {
     poolId: poolId?.toLowerCase(),
     ...(poolTypeFilter?.length ? { poolTypes: poolTypeFilter } : {}),
-  };
+  }
+
   const { data: poolsData } = pools
     .gql(network || "1")
     .usePoolsWherePoolTypeInAndId(gqlVariables, { revalidateIfStale: true });
@@ -75,20 +76,6 @@ export function SearchPoolForm({
     onSubmit?.(formData);
     close?.();
     closeCombobox();
-  }
-
-  function filterPoolInput({
-    poolSearchQuery,
-    pool,
-  }: {
-    poolSearchQuery: string;
-    pool?: ArrElement<GetDeepProp<PoolsWherePoolTypeQuery, "pools">>;
-  }) {
-    {
-      if (!pool) return false;
-      const regex = new RegExp(poolSearchQuery, "i");
-      return regex.test(Object.values(pool).join(","));
-    }
   }
 
   const filteredPoolList = poolsDataList?.pools
@@ -111,12 +98,12 @@ export function SearchPoolForm({
     } else {
       clearErrors("poolId");
     }
-  }, [poolsData]);
+  }, [poolsData, poolId, setError, clearErrors]);
 
   useLayoutEffect(() => {
     poolsDataListMutate();
     resetField("poolId");
-  }, [network]);
+  }, [network, poolsDataListMutate, resetField]);
 
   function closeCombobox() {
     setTimeout(() => {

--- a/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
+++ b/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
@@ -77,8 +77,9 @@ export function SearchPoolForm({
     closeCombobox();
   }
 
-  const filteredPoolList = poolsDataList?.pools
-    .filter((pool) => filterPoolInput({ poolSearchQuery: poolId, pool }))
+  const filteredPoolList = poolsDataList?.pools.filter((pool) =>
+    filterPoolInput({ poolSearchQuery: poolId, pool }),
+  );
 
   useEffect(() => {
     if (poolsData && !poolsData.pools && poolId) {

--- a/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
+++ b/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ReactNode, useEffect, useLayoutEffect, useState } from "react";
-import { useForm,UseFormReturn } from "react-hook-form";
+import { useForm, UseFormReturn } from "react-hook-form";
 
 import Button from "#/components/Button";
 import { Input } from "#/components/Input";
@@ -23,7 +23,6 @@ const inputTypenames = [
   { value: "42161", label: "Arbitrum" },
   { value: "5", label: "Goerli" },
 ];
-
 
 export function SearchPoolForm({
   close,
@@ -58,7 +57,7 @@ export function SearchPoolForm({
   const gqlVariables = {
     poolId: poolId?.toLowerCase(),
     ...(poolTypeFilter?.length ? { poolTypes: poolTypeFilter } : {}),
-  }
+  };
 
   const { data: poolsData } = pools
     .gql(network || "1")

--- a/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
+++ b/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
@@ -79,9 +79,6 @@ export function SearchPoolForm({
 
   const filteredPoolList = poolsDataList?.pools
     .filter((pool) => filterPoolInput({ poolSearchQuery: poolId, pool }))
-    .sort((a, b) =>
-      Number(a!.totalLiquidity) < Number(b!.totalLiquidity) ? 1 : -1,
-    );
 
   useEffect(() => {
     if (poolsData && !poolsData.pools && poolId) {

--- a/apps/balancer-tools/src/components/SearchPoolForm/isValuePresent.test.ts
+++ b/apps/balancer-tools/src/components/SearchPoolForm/isValuePresent.test.ts
@@ -1,0 +1,69 @@
+import { isValuePresent } from "./isValuePresent";
+
+describe("isValuePresent function", () => {
+  const regex = /hello/;
+
+  it("should return true for a matching string", () => {
+    expect(isValuePresent("hello world", regex)).toBe(true);
+  });
+
+  it("should return false for a non-matching string", () => {
+    expect(isValuePresent("goodbye world", regex)).toBe(false);
+  });
+
+  it("should return true for a matching string inside an array", () => {
+    expect(isValuePresent(["goodbye world", "hello universe"], regex)).toBe(
+      true,
+    );
+  });
+
+  it("should return false for a non-matching string inside an array", () => {
+    expect(isValuePresent(["goodbye world", "farewell universe"], regex)).toBe(
+      false,
+    );
+  });
+
+  it("should return true for a matching string inside an object", () => {
+    expect(
+      isValuePresent(
+        { greeting1: "goodbye world", greeting2: "hello universe" },
+        regex,
+      ),
+    ).toBe(true);
+  });
+
+  it("should return false for a non-matching string inside an object", () => {
+    expect(
+      isValuePresent(
+        { greeting1: "goodbye world", greeting2: "farewell universe" },
+        regex,
+      ),
+    ).toBe(false);
+  });
+
+  it("should return true for a matching string inside a nested object", () => {
+    const nestedObj = {
+      greeting1: "goodbye world",
+      inner: {
+        greeting2: "hello universe",
+      },
+    };
+    expect(isValuePresent(nestedObj, regex)).toBe(true);
+  });
+
+  it("should return true for a matching string inside a nested array", () => {
+    const nestedArray = ["goodbye world", ["farewell", "hello universe"]];
+    expect(isValuePresent(nestedArray, regex)).toBe(true);
+  });
+
+  it("should return false for a non-matching string inside a nested structure", () => {
+    const nestedStructure = {
+      greeting1: "goodbye world",
+      innerArray: ["farewell", "adios universe"],
+      innerObj: {
+        greeting2: "ciao world",
+      },
+    };
+    expect(isValuePresent(nestedStructure, regex)).toBe(false);
+  });
+});

--- a/apps/balancer-tools/src/components/SearchPoolForm/isValuePresent.ts
+++ b/apps/balancer-tools/src/components/SearchPoolForm/isValuePresent.ts
@@ -1,0 +1,20 @@
+export function isValuePresent(value: unknown, regex: RegExp): boolean {
+  // Check if the value is a string and matches the regex
+  if (typeof value === "string") {
+    return regex.test(value);
+  }
+
+  // Recursively check if any of the array values match the regex
+  if (Array.isArray(value)) {
+    return value.some((item) => isValuePresent(item, regex));
+  }
+
+  // Recursively check if any of the object values match the regex
+  if (typeof value === "object" && value !== null) {
+    return Object.values(value).some((subValue) =>
+      isValuePresent(subValue, regex),
+    );
+  }
+
+  return false;
+}

--- a/apps/balancer-tools/src/data/voting-gauges.json
+++ b/apps/balancer-tools/src/data/voting-gauges.json
@@ -1,0 +1,6669 @@
+[
+  {
+    "address": "0xb78543e00712C3ABBA10D0852f6E38FDE2AaBA4d",
+    "network": 1,
+    "isKilled": false,
+    "addedTimestamp": 1648465251,
+    "relativeWeightCap": "0.10",
+    "pool": {
+      "id": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+      "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
+      "poolType": "Stable",
+      "symbol": "veBAL",
+      "tokens": [
+        {
+          "address": "0xc128a9954e6c874ea3d62ce62b468ba073093f25",
+          "weight": "null",
+          "symbol": "veBAL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xc128a9954e6c874ea3d62ce62b468ba073093f25": "https://raw.githubusercontent.com/balancer/assets/master/assets/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png"
+    }
+  },
+  {
+    "address": "0xF2ca6F8961e91F1ee0D688F9926183314D866f1E",
+    "network": 5,
+    "addedTimestamp": 1654312627,
+    "relativeWeightCap": "null",
+    "pool": {
+      "id": "0xf8a0623ab66f985effc1c69d05f1af4badb01b00000200000000000000000060",
+      "address": "0xf8a0623ab66F985EfFc1C69D05F1af4BaDB01b00",
+      "poolType": "Stable",
+      "symbol": "veBAL",
+      "tokens": [
+        {
+          "address": "0x33A99Dcc4C85C014cf12626959111D5898bbCAbF",
+          "weight": "null",
+          "symbol": "veBAL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x33A99Dcc4C85C014cf12626959111D5898bbCAbF": "https://raw.githubusercontent.com/balancer/assets/master/assets/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png"
+    }
+  },
+  {
+    "address": "0x56124eb16441A1eF12A4CCAeAbDD3421281b795A",
+    "network": 1,
+    "addedTimestamp": 1679160753,
+    "relativeWeightCap": "null",
+    "pool": {
+      "id": "0x9232a548dd9e81bac65500b5e0d918f8ba93675c000200000000000000000423",
+      "address": "0x9232a548DD9E81BaC65500b5e0d918F8Ba93675C",
+      "poolType": "Stable",
+      "symbol": "veLIT",
+      "tokens": [
+        {
+          "address": "0xf17d23136B4FeAd139f54fB766c8795faae09660",
+          "weight": "null",
+          "symbol": "veLIT"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xf17d23136B4FeAd139f54fB766c8795faae09660": "https://raw.githubusercontent.com/balancer/assets/master/assets/0xfd0205066521550d7d7ab19da8f72bb004b4c341.png"
+    }
+  },
+  {
+    "address": "0x5b79494824Bc256cD663648Ee1Aad251B32693A9",
+    "network": 1,
+    "addedTimestamp": 1679160753,
+    "relativeWeightCap": "null",
+    "pool": {
+      "id": "0xd689abc77b82803f22c49de5c8a0049cc74d11fd000200000000000000000524",
+      "address": "0xd689ABc77B82803F22c49dE5C8A0049Cc74D11fD",
+      "poolType": "Stable",
+      "symbol": "veUSH",
+      "tokens": [
+        {
+          "address": "0xd027Ef82dB658805C9Ba8053196cD6ED1Dd407E4",
+          "weight": "null",
+          "symbol": "veUSH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xf17d23136B4FeAd139f54fB766c8795faae09660": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe60779cc1b2c1d0580611c526a8df0e3f870ec48.png"
+    }
+  },
+  {
+    "address": "0x145011e0C04805E11BEf23c1EEd848Faf49bB779",
+    "network": 137,
+    "isKilled": false,
+    "addedTimestamp": 1663017781,
+    "relativeWeightCap": "null",
+    "pool": {
+      "id": "0x726e324c29a1e49309672b244bdc4ff62a270407000200000000000000000702",
+      "address": "0x726E324c29a1e49309672b244bdC4Ff62A270407",
+      "poolType": "FX",
+      "symbol": "XSGD-USDC",
+      "tokens": [
+        {
+          "address": "0xDC3326e71D45186F113a2F448984CA0e8D201995",
+          "weight": "null",
+          "symbol": "XSGD"
+        },
+        {
+          "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+          "weight": "null",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xDC3326e71D45186F113a2F448984CA0e8D201995": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96/logo.png",
+      "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png"
+    }
+  },
+  {
+    "address": "0xB5bd58C733948e3d65d86BA9604e06e5dA276FD1",
+    "network": 1,
+    "isKilled": false,
+    "addedTimestamp": 1663017781,
+    "relativeWeightCap": "null",
+    "pool": {
+      "id": "0x6910c4e32d425a834fb61e983c8083a84b0ebd01000200000000000000000532",
+      "address": "0x6910C4e32D425a834Fb61e983C8083a84b0EBd01",
+      "poolType": "TWAMM",
+      "symbol": "wstETH/rETH/L",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0xD103Dd49B8051A09B399A52E9A8aB629392dE2fb",
+    "network": 137,
+    "isKilled": false,
+    "addedTimestamp": 1663017781,
+    "relativeWeightCap": "null",
+    "pool": {
+      "id": "0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2000200000000000000000b49",
+      "address": "0xf0ad209e2e969EAAA8C882aac71f02D8a047d5c2",
+      "poolType": "ComposableStable",
+      "symbol": "ECLP-WMATIC-stMATIC",
+      "tokens": [
+        {
+          "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+          "weight": "null",
+          "symbol": "WMATIC"
+        },
+        {
+          "address": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+          "weight": "null",
+          "symbol": "stMATIC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+      "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png"
+    }
+  },
+  {
+    "address": "0x730A168cF6F501cf302b803FFc57FF3040f378Bf",
+    "network": 10,
+    "isKilled": false,
+    "addedTimestamp": 1688418508,
+    "relativeWeightCap": "0.10",
+    "pool": {
+      "id": "0x7ca75bdea9dede97f8b13c6641b768650cb837820002000000000000000000d5",
+      "address": "0x7Ca75bdEa9dEde97F8B13C6641B768650CB83782",
+      "poolType": "ComposableStable",
+      "symbol": "ECLP-wstETH-WETH",
+      "tokens": [
+        {
+          "address": "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0x4200000000000000000000000000000000000006",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x1f32b1c2345538c0c6f582fcb022739c4a194ebb.png",
+      "0x4200000000000000000000000000000000000006": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4200000000000000000000000000000000000006.png"
+    }
+  },
+  {
+    "address": "0xC4E72abE8A32Fd7D7BA787e1Ec860ecb8C0B333c",
+    "network": 1,
+    "isKilled": false,
+    "addedTimestamp": 1690387253,
+    "relativeWeightCap": "0.02",
+    "pool": {
+      "id": "0x0018c32d85d8aebea2efbe0b0f4a4eb9e4f1c8c900020000000000000000050c",
+      "address": "0x0018C32D85D8AebEA2eFbE0b0F4a4Eb9e4F1C8C9",
+      "poolType": "TWAMM",
+      "symbol": "USDC/WETH/L",
+      "tokens": [
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "null",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x34f33CDaED8ba0E1CEECE80e5f4a73bcf234cfac",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063",
+      "address": "0x06Df3b2bbB68adc8B0e302443692037ED9f91b42",
+      "poolType": "Stable",
+      "symbol": "staBAL3",
+      "tokens": [
+        {
+          "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "weight": "null",
+          "symbol": "DAI"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "null",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "weight": "null",
+          "symbol": "USDT"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    }
+  },
+  {
+    "address": "0x605eA53472A496c3d483869Fe8F355c12E861e19",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0x072f14b85add63488ddad88f855fda4a99d6ac9b000200000000000000000027",
+      "address": "0x072f14B85ADd63488DDaD88f855Fda4A99d6aC9B",
+      "poolType": "Weighted",
+      "symbol": "B-50SNX-50WETH",
+      "tokens": [
+        {
+          "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
+          "weight": "0.5",
+          "symbol": "SNX"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x4ca6AC0509E6381Ca7CD872a6cdC0Fbf00600Fa1",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a",
+      "address": "0x0b09deA16768f0799065C475bE02919503cB2a35",
+      "poolType": "Weighted",
+      "symbol": "B-60WETH-40DAI",
+      "tokens": [
+        {
+          "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "weight": "0.4",
+          "symbol": "DAI"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.6",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x79eF6103A513951a3b25743DB509E267685726B7",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0x1e19cf2d73a72ef1332c882f20534b6519be0276000200000000000000000112",
+      "address": "0x1E19CF2D73a72Ef1332C882F20534B6519Be0276",
+      "poolType": "MetaStable",
+      "symbol": "B-rETH-STABLE",
+      "tokens": [
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "null",
+          "symbol": "rETH"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x1249c510e066731FF14422500466A7102603da9e",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662504532,
+    "pool": {
+      "id": "0x27c9f71cc31464b906e0006d4fcbc8900f48f15f00020000000000000000010f",
+      "address": "0x27C9f71cC31464B906E0006d4FcBC8900F48f15f",
+      "poolType": "Weighted",
+      "symbol": "80D2D-20USDC",
+      "tokens": [
+        {
+          "address": "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad",
+          "weight": "0.8",
+          "symbol": "D2D"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.2",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0x5A481455E62D5825429C8c416f3B8D2938755B64",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0x27c9f71cc31464b906e0006d4fcbc8900f48f15f00020000000000000000010f",
+      "address": "0x27C9f71cC31464B906E0006d4FcBC8900F48f15f",
+      "poolType": "Weighted",
+      "symbol": "80D2D-20USDC",
+      "tokens": [
+        {
+          "address": "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad",
+          "weight": "0.8",
+          "symbol": "D2D"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.2",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0xcD4722B7c24C29e0413BDCd9e51404B4539D14aE",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080",
+      "address": "0x32296969Ef14EB0c6d29669C550D4a0449130230",
+      "poolType": "MetaStable",
+      "symbol": "B-stETH-STABLE",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xc2D343E2C9498E905F53C818B88eB8064B42D036",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662504532,
+    "pool": {
+      "id": "0x350196326aeaa9b98f1903fb5e8fc2686f85318c000200000000000000000084",
+      "address": "0x350196326AEAA9b98f1903fb5e8fc2686f85318C",
+      "poolType": "Weighted",
+      "symbol": "VBPT",
+      "tokens": [
+        {
+          "address": "0x81f8f0bb1cB2A06649E51913A151F0E7Ef6FA321",
+          "weight": "0.8",
+          "symbol": "VITA"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x81f8f0bb1cB2A06649E51913A151F0E7Ef6FA321": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x9AB7B0C7b154f626451c9e8a68dC04f58fb6e5Ce",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019",
+      "address": "0x96646936b91d6B9D7D0c47C496AfBF3D6ec7B6f8",
+      "poolType": "Weighted",
+      "symbol": "B-50USDC-50WETH",
+      "tokens": [
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.5",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x4e311e207CEAaaed421F17E909DA16527565Daef",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a00020000000000000000004b",
+      "address": "0xa02E4b3d18D4E6B8d18Ac421fBc3dfFF8933c40a",
+      "poolType": "Weighted",
+      "symbol": "B-50MATIC-50WETH",
+      "tokens": [
+        {
+          "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+          "weight": "0.5",
+          "symbol": "MATIC"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x4E3c048BE671852277Ad6ce29Fd5207aA12fabff",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e",
+      "address": "0xA6F548DF93de924d73be7D25dC02554c6bD66dB5",
+      "poolType": "Weighted",
+      "symbol": "B-50WBTC-50WETH",
+      "tokens": [
+        {
+          "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+          "weight": "0.5",
+          "symbol": "WBTC"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x777C45BD0a2AF1dA5fe4a532AD6B207D3CEd8b2d",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1663170555,
+    "pool": {
+      "id": "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d00020000000000000000008a",
+      "address": "0xBaeEC99c90E3420Ec6c1e7A769d2A856d2898e4D",
+      "poolType": "Weighted",
+      "symbol": "B-50VITA-50WETH",
+      "tokens": [
+        {
+          "address": "0x81f8f0bb1cB2A06649E51913A151F0E7Ef6FA321",
+          "weight": "0.5",
+          "symbol": "VITA"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x81f8f0bb1cB2A06649E51913A151F0E7Ef6FA321": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x942CB1Ed80D3FF8028B3DD726e0E2A9671bc6202",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087",
+      "address": "0xBF96189Eee9357a95C7719f4F5047F76bdE804E5",
+      "poolType": "Weighted",
+      "symbol": "B-80LDO-20WETH",
+      "tokens": [
+        {
+          "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+          "weight": "0.8",
+          "symbol": "LDO"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5a98fcbea516cf06857215779fd812ca3bef1b32.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xAFc28B2412B343574E8673D4fb6b220473677602",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021",
+      "address": "0xEFAa1604e82e1B3AF8430b90192c1B9e8197e377",
+      "poolType": "Weighted",
+      "symbol": "B-50COMP-50WETH",
+      "tokens": [
+        {
+          "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+          "weight": "0.5",
+          "symbol": "COMP"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xc00e94Cb662C3520282E6f5717214004A7f26888": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xCB664132622f29943f67FA56CCfD1e24CC8B4995",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1648465429,
+    "pool": {
+      "id": "0xf4c0dd9b82da36c07605df83c8a416f11724d88b000200000000000000000026",
+      "address": "0xF4C0DD9B82DA36C07605df83c8a416F11724d88b",
+      "poolType": "Weighted",
+      "symbol": "B-80GNO-20WETH",
+      "tokens": [
+        {
+          "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
+          "weight": "0.8",
+          "symbol": "GNO"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6810e776880C02933D47DB1b9fc05908e5386b96": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x57AB3b673878C3fEaB7f8FF434C40Ab004408c4c",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1663170555,
+    "pool": {
+      "id": "0x92762b42a06dcdddc5b7362cfb01e631c4d44b40000200000000000000000182",
+      "address": "0x92762B42A06dCDDDc5B7362Cfb01E631c4D44B40",
+      "poolType": "Weighted",
+      "symbol": "50COW-50GNO",
+      "tokens": [
+        {
+          "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
+          "weight": "0.5",
+          "symbol": "GNO"
+        },
+        {
+          "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+          "weight": "0.5",
+          "symbol": "COW"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6810e776880C02933D47DB1b9fc05908e5386b96": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+      "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab.png"
+    }
+  },
+  {
+    "address": "0x7C777eEA1dC264e71E567Fcc9B6DdaA9064Eff51",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1663170555,
+    "pool": {
+      "id": "0xde8c195aa41c11a0c4787372defbbddaa31306d2000200000000000000000181",
+      "address": "0xde8C195Aa41C11a0c4787372deFBbDdAa31306D2",
+      "poolType": "Weighted",
+      "symbol": "50COW-50WETH",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+          "weight": "0.5",
+          "symbol": "COW"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab.png"
+    }
+  },
+  {
+    "address": "0x3F29e69955E5202759208DD0C5E0BA55ff934814",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662504532,
+    "pool": {
+      "id": "0xb460daa847c45f1c4a41cb05bfb3b51c92e41b36000200000000000000000194",
+      "address": "0xb460DAa847c45f1C4a41cb05BFB3b51c92e41B36",
+      "poolType": "Weighted",
+      "symbol": "20WBTC-80BADGER",
+      "tokens": [
+        {
+          "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+          "weight": "0.2",
+          "symbol": "WBTC"
+        },
+        {
+          "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
+          "weight": "0.8",
+          "symbol": "BADGER"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+      "0x3472A5A71965499acd81997a54BBA8D852C6E53d": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3472A5A71965499acd81997a54BBA8D852C6E53d/logo.png"
+    }
+  },
+  {
+    "address": "0xAF50825B010Ae4839Ac444f6c12D44b96819739B",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1651667561,
+    "pool": {
+      "id": "0xb460daa847c45f1c4a41cb05bfb3b51c92e41b36000200000000000000000194",
+      "address": "0xb460DAa847c45f1C4a41cb05BFB3b51c92e41B36",
+      "poolType": "Weighted",
+      "symbol": "20WBTC-80BADGER",
+      "tokens": [
+        {
+          "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+          "weight": "0.2",
+          "symbol": "WBTC"
+        },
+        {
+          "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
+          "weight": "0.8",
+          "symbol": "BADGER"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+      "0x3472A5A71965499acd81997a54BBA8D852C6E53d": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3472A5A71965499acd81997a54BBA8D852C6E53d/logo.png"
+    }
+  },
+  {
+    "address": "0x09AFEc27F5A6201617aAd014CeEa8deb572B0608",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662504532,
+    "pool": {
+      "id": "0x5122e01d819e58bb2e22528c0d68d310f0aa6fd7000200000000000000000163",
+      "address": "0x5122E01D819E58BB2E22528c0D68D310f0AA6FD7",
+      "poolType": "Weighted",
+      "symbol": "sNOTE-BPT",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xCFEAead4947f0705A14ec42aC3D44129E1Ef3eD5",
+          "weight": "0.8",
+          "symbol": "NOTE"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xCFEAead4947f0705A14ec42aC3D44129E1Ef3eD5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5.png"
+    }
+  },
+  {
+    "address": "0x47c56A900295df5224EC5e6751dC31eb900321D5",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662504532,
+    "pool": {
+      "id": "0xe8cc7e765647625b95f59c15848379d10b9ab4af0002000000000000000001de",
+      "address": "0xe8cc7E765647625B95F59C15848379D10B9AB4af",
+      "poolType": "Weighted",
+      "symbol": "20WETH-80WNCG",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xf203Ca1769ca8e9e8FE1DA9D147DB68B6c919817",
+          "weight": "0.8",
+          "symbol": "WNCG"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xf203Ca1769ca8e9e8FE1DA9D147DB68B6c919817": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf203ca1769ca8e9e8fe1da9d147db68b6c919817.png"
+    }
+  },
+  {
+    "address": "0xe2b680A8d02fbf48C7D9465398C4225d7b7A7f87",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662504532,
+    "pool": {
+      "id": "0xa7ff759dbef9f3efdd1d59beee44b966acafe214000200000000000000000180",
+      "address": "0xA7Ff759DBeF9F3EFDD1d59Beee44b966AcAfe214",
+      "poolType": "Weighted",
+      "symbol": "USDC-PAL",
+      "tokens": [
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.2",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xAB846Fb6C81370327e784Ae7CbB6d6a6af6Ff4BF",
+          "weight": "0.8",
+          "symbol": "PAL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+      "0xAB846Fb6C81370327e784Ae7CbB6d6a6af6Ff4BF": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf.png"
+    }
+  },
+  {
+    "address": "0xe3A3Ca91794a995fe0bB24060987e73931B15f3D",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1654206637,
+    "pool": {
+      "id": "0xa7ff759dbef9f3efdd1d59beee44b966acafe214000200000000000000000180",
+      "address": "0xA7Ff759DBeF9F3EFDD1d59Beee44b966AcAfe214",
+      "poolType": "Weighted",
+      "symbol": "USDC-PAL",
+      "tokens": [
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.2",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xAB846Fb6C81370327e784Ae7CbB6d6a6af6Ff4BF",
+          "weight": "0.8",
+          "symbol": "PAL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+      "0xAB846Fb6C81370327e784Ae7CbB6d6a6af6Ff4BF": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf.png"
+    }
+  },
+  {
+    "address": "0x27Fd581E9D0b2690C2f808cd40f7fe667714b575",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662504532,
+    "pool": {
+      "id": "0x3f7c10701b14197e2695dec6428a2ca4cf7fc3b800020000000000000000023c",
+      "address": "0x3F7C10701b14197E2695dEC6428a2Ca4Cf7FC3B8",
+      "poolType": "Weighted",
+      "symbol": "50DFX-50WETH",
+      "tokens": [
+        {
+          "address": "0x888888435FDe8e7d4c54cAb67f206e4199454c60",
+          "weight": "0.5",
+          "symbol": "DFX"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x888888435FDe8e7d4c54cAb67f206e4199454c60": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x888888435fde8e7d4c54cab67f206e4199454c60.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xDc2Df969EE5E66236B950F5c4c5f8aBe62035df2",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1655755330,
+    "pool": {
+      "id": "0x2d011adf89f0576c9b722c28269fcb5d50c2d17900020000000000000000024d",
+      "address": "0x2d011aDf89f0576C9B722c28269FcB5D50C2d179",
+      "poolType": "Stable",
+      "symbol": "B-sdBAL-STABLE",
+      "tokens": [
+        {
+          "address": "0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56",
+          "weight": "null",
+          "symbol": "B-80BAL-20WETH"
+        },
+        {
+          "address": "0xF24d8651578a55b0C119B9910759a351A3458895",
+          "weight": "null",
+          "symbol": "sdBal"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png",
+      "0xF24d8651578a55b0C119B9910759a351A3458895": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf24d8651578a55b0c119b9910759a351a3458895.png"
+    }
+  },
+  {
+    "address": "0xDD4Db3ff8A37FE418dB6FF34fC316655528B6bbC",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1656343230,
+    "pool": {
+      "id": "0x178e029173417b1f9c8bc16dcec6f697bc32374600000000000000000000025d",
+      "address": "0x178E029173417b1F9C8bC16DCeC6f697bC323746",
+      "poolType": "Stable",
+      "symbol": "FUD",
+      "tokens": [
+        {
+          "address": "0x586Aa273F262909EEF8fA02d90Ab65F5015e0516",
+          "weight": "null",
+          "symbol": "FIAT"
+        },
+        {
+          "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "weight": "null",
+          "symbol": "DAI"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "null",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x586Aa273F262909EEF8fA02d90Ab65F5015e0516": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x586aa273f262909eef8fa02d90ab65f5015e0516.png",
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0x275dF57d2B23d53e20322b4bb71Bf1dCb21D0A00",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1656894825,
+    "pool": {
+      "id": "0xcfca23ca9ca720b6e98e3eb9b6aa0ffc4a5c08b9000200000000000000000274",
+      "address": "0xCfCA23cA9CA720B6E98E3Eb9B6aa0fFC4a5C08B9",
+      "poolType": "Weighted",
+      "symbol": "50WETH-50AURA",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
+          "weight": "0.5",
+          "symbol": "AURA"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc0c293ce456ff0ed870add98a0828dd4d2903dbf.png"
+    }
+  },
+  {
+    "address": "0x0312AA8D0BA4a1969Fddb382235870bF55f7f242",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1656894825,
+    "pool": {
+      "id": "0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249",
+      "address": "0x3dd0843A028C86e0b760b1A76929d1C5Ef93a2dd",
+      "poolType": "Stable",
+      "symbol": "B-auraBAL-STABLE",
+      "tokens": [
+        {
+          "address": "0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56",
+          "weight": "null",
+          "symbol": "B-80BAL-20WETH"
+        },
+        {
+          "address": "0x616e8BfA43F920657B3497DBf40D6b1A02D4608d",
+          "weight": "null",
+          "symbol": "auraBAL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png",
+      "0x616e8BfA43F920657B3497DBf40D6b1A02D4608d": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d.png"
+    }
+  },
+  {
+    "address": "0x2e79D6f631177F8E7f08Fbd5110e893e1b1D790A",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1657043538,
+    "pool": {
+      "id": "0x0578292cb20a443ba1cde459c985ce14ca2bdee5000100000000000000000269",
+      "address": "0x0578292CB20a443bA1CdE459c985CE14Ca2bDEe5",
+      "poolType": "Weighted",
+      "symbol": "33auraBAL-33graviAURA-33WETH",
+      "tokens": [
+        {
+          "address": "0x616e8BfA43F920657B3497DBf40D6b1A02D4608d",
+          "weight": "0.3333",
+          "symbol": "auraBAL"
+        },
+        {
+          "address": "0xBA485b556399123261a5F9c95d413B4f93107407",
+          "weight": "0.3334",
+          "symbol": "graviAURA"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.3333",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x616e8BfA43F920657B3497DBf40D6b1A02D4608d": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d.png",
+      "0xBA485b556399123261a5F9c95d413B4f93107407": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba485b556399123261a5f9c95d413b4f93107407.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xE5f24cD43f77fadF4dB33Dab44EB25774159AC66",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662504532,
+    "pool": {
+      "id": "0x8eb6c82c3081bbbd45dcac5afa631aac53478b7c000100000000000000000270",
+      "address": "0x8eB6c82C3081bBBd45DcAC5afA631aaC53478b7C",
+      "poolType": "Weighted",
+      "symbol": "40WBTC-40DIGG-20graviAURA",
+      "tokens": [
+        {
+          "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+          "weight": "0.4",
+          "symbol": "WBTC"
+        },
+        {
+          "address": "0x798D1bE841a82a273720CE31c822C61a67a601C3",
+          "weight": "0.4",
+          "symbol": "DIGG"
+        },
+        {
+          "address": "0xBA485b556399123261a5F9c95d413B4f93107407",
+          "weight": "0.2",
+          "symbol": "graviAURA"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+      "0x798D1bE841a82a273720CE31c822C61a67a601C3": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x798D1bE841a82a273720CE31c822C61a67a601C3/logo.png",
+      "0xBA485b556399123261a5F9c95d413B4f93107407": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba485b556399123261a5f9c95d413b4f93107407.png"
+    }
+  },
+  {
+    "address": "0xAf3c3dab54ca15068D09C67D128344916e177cA9",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1660580290,
+    "pool": {
+      "id": "0x99a14324cfd525a34bbc93ac7e348929909d57fd00020000000000000000030e",
+      "address": "0x99A14324Cfd525A34BBc93ac7e348929909D57fD",
+      "poolType": "Weighted",
+      "symbol": "50WETH-50FOLD",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xd084944d3c05CD115C09d072B9F44bA3E0E45921",
+          "weight": "0.5",
+          "symbol": "FOLD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xd084944d3c05CD115C09d072B9F44bA3E0E45921": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd084944d3c05cd115c09d072b9f44ba3e0e45921.png"
+    }
+  },
+  {
+    "address": "0x75cAceBb5b4a73a530EdcdFdE7cFfbfea44c026E",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1662557059,
+    "pool": {
+      "id": "0x48607651416a943bf5ac71c41be1420538e78f87000200000000000000000327",
+      "address": "0x48607651416A943bF5AC71C41BE1420538e78f87",
+      "poolType": "Weighted",
+      "symbol": "50Silo-50WETH",
+      "tokens": [
+        {
+          "address": "0x6f80310CA7F2C654691D1383149Fa1A57d8AB1f8",
+          "weight": "0.5",
+          "symbol": "Silo"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6f80310CA7F2C654691D1383149Fa1A57d8AB1f8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xc2c2304E163e1aB53De2eEB08820a0B592bec20B",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1663017781,
+    "pool": {
+      "id": "0x6a5ead5433a50472642cd268e584dafa5a394490000200000000000000000366",
+      "address": "0x6a5EaD5433a50472642Cd268E584dafa5a394490",
+      "poolType": "Weighted",
+      "symbol": "50WSTETH-50LDO",
+      "tokens": [
+        {
+          "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+          "weight": "0.5",
+          "symbol": "LDO"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5a98fcbea516cf06857215779fd812ca3bef1b32.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0x46804462f147fF96e9CAFB20cA35A3B2600656DF",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1663017781,
+    "pool": {
+      "id": "0x441b8a1980f2f2e43a9397099d15cc2fe6d3625000020000000000000000035f",
+      "address": "0x441b8a1980f2F2E43A9397099d15CC2Fe6D36250",
+      "poolType": "Weighted",
+      "symbol": "50INV-50DOLA",
+      "tokens": [
+        {
+          "address": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68",
+          "weight": "0.5",
+          "symbol": "INV"
+        },
+        {
+          "address": "0x865377367054516e17014CcdED1e7d814EDC9ce4",
+          "weight": "0.5",
+          "symbol": "DOLA"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x41d5d79431a913c4ae7d69a668ecdfe5ff9dfb68.png",
+      "0x865377367054516e17014CcdED1e7d814EDC9ce4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x865377367054516e17014ccded1e7d814edc9ce4.png"
+    }
+  },
+  {
+    "address": "0xa6325e799d266632D347e41265a69aF111b05403",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1663017781,
+    "pool": {
+      "id": "0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d",
+      "address": "0xA13a9247ea42D743238089903570127DdA72fE44",
+      "poolType": "ComposableStable",
+      "symbol": "bb-a-USD",
+      "tokens": [
+        {
+          "address": "0x2F4eb100552ef93840d5aDC30560E5513DFfFACb",
+          "weight": "null",
+          "symbol": "bb-a-USDT"
+        },
+        {
+          "address": "0x82698aeCc9E28e9Bb27608Bd52cF57f704BD1B83",
+          "weight": "null",
+          "symbol": "bb-a-USDC"
+        },
+        {
+          "address": "0xae37D54Ae477268B9997d4161B96b8200755935c",
+          "weight": "null",
+          "symbol": "bb-a-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2F4eb100552ef93840d5aDC30560E5513DFfFACb": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x2f4eb100552ef93840d5adc30560e5513dfffacb.png",
+      "0x82698aeCc9E28e9Bb27608Bd52cF57f704BD1B83": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x82698aecc9e28e9bb27608bd52cf57f704bd1b83.png",
+      "0xae37D54Ae477268B9997d4161B96b8200755935c": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae37d54ae477268b9997d4161b96b8200755935c.png"
+    }
+  },
+  {
+    "address": "0x9C0f4144D037688e0AdA74B22a9aAb7c14c58e6C",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1664866055,
+    "pool": {
+      "id": "0x496ff26b76b8d23bbc6cf1df1eee4a48795490f7000200000000000000000377",
+      "address": "0x496ff26B76b8d23bbc6cF1Df1eeE4a48795490F7",
+      "poolType": "Weighted",
+      "symbol": "50COMP-50WSTETH",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+          "weight": "0.5",
+          "symbol": "COMP"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xc00e94Cb662C3520282E6f5717214004A7f26888": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    }
+  },
+  {
+    "address": "0x651361a042e0573295dd7f6A84dBD1DA56DAc9D5",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1665943619,
+    "pool": {
+      "id": "0x25accb7943fd73dda5e23ba6329085a3c24bfb6a000200000000000000000387",
+      "address": "0x25Accb7943Fd73Dda5E23bA6329085a3C24bfb6a",
+      "poolType": "Weighted",
+      "symbol": "50wstETH-50bb-a-USD",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xA13a9247ea42D743238089903570127DdA72fE44",
+          "weight": "0.5",
+          "symbol": "bb-a-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xA13a9247ea42D743238089903570127DdA72fE44": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa13a9247ea42d743238089903570127dda72fe44.png"
+    }
+  },
+  {
+    "address": "0xb32Ae42524d38be7E7eD9E02b5F9330fCEf07f3F",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1666607687,
+    "pool": {
+      "id": "0xe340ebfcaa544da8bb1ee9005f1a346d50ec422e000200000000000000000396",
+      "address": "0xe340EBfcAA544da8bB1Ee9005F1a346D50Ec422e",
+      "poolType": "Weighted",
+      "symbol": "50BADGER-50rETH",
+      "tokens": [
+        {
+          "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
+          "weight": "0.5",
+          "symbol": "BADGER"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "0.5",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3472A5A71965499acd81997a54BBA8D852C6E53d": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3472A5A71965499acd81997a54BBA8D852C6E53d/logo.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0x39a9E78c3b9b5B47f1f6632BD74890E2430215Cf",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1667337815,
+    "pool": {
+      "id": "0xae7bfd6fa54259fc477879712eebe34164d3a84f000200000000000000000376",
+      "address": "0xae7bFd6fA54259fC477879712Eebe34164d3A84F",
+      "poolType": "Weighted",
+      "symbol": "80palStkAAVE-20AAVE",
+      "tokens": [
+        {
+          "address": "0x24E79e946dEa5482212c38aaB2D0782F04cdB0E0",
+          "weight": "0.8",
+          "symbol": "palStkAAVE"
+        },
+        {
+          "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+          "weight": "0.2",
+          "symbol": "AAVE"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x24E79e946dEa5482212c38aaB2D0782F04cdB0E0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x24e79e946dea5482212c38aab2d0782f04cdb0e0.png",
+      "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png"
+    }
+  },
+  {
+    "address": "0x9703C0144e8b68280b97d9e30aC6f979Dd6A38d7",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1667776463,
+    "pool": {
+      "id": "0x4ce0bd7debf13434d3ae127430e9bd4291bfb61f00020000000000000000038b",
+      "address": "0x4ce0BD7deBf13434d3ae127430e9BD4291bfB61f",
+      "poolType": "Weighted",
+      "symbol": "50STG-50bb-a-USD",
+      "tokens": [
+        {
+          "address": "0xA13a9247ea42D743238089903570127DdA72fE44",
+          "weight": "0.5",
+          "symbol": "bb-a-USD"
+        },
+        {
+          "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+          "weight": "0.5",
+          "symbol": "STG"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xA13a9247ea42D743238089903570127DdA72fE44": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa13a9247ea42d743238089903570127dda72fe44.png",
+      "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6.png"
+    }
+  },
+  {
+    "address": "0x3F0FB52648Eb3981EA598716b7320081d1c8Ba1a",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1667776463,
+    "pool": {
+      "id": "0x8e85e97ed19c0fa13b2549309965291fbbc0048b0000000000000000000003ba",
+      "address": "0x8e85e97ed19C0fa13B2549309965291fbbc0048b",
+      "poolType": "ComposableStable",
+      "symbol": "sfrxETH-stETH-rETH-BPT",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xac3E018457B222d93114458476f3E3416Abbe38F",
+          "weight": "null",
+          "symbol": "sfrxETH"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xac3E018457B222d93114458476f3E3416Abbe38F": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xac3e018457b222d93114458476f3e3416abbe38f.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0x7Fc115BF013844D6eF988837F7ae6398af153532",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1668369023,
+    "pool": {
+      "id": "0x8167a1117691f39e05e9131cfa88f0e3a620e96700020000000000000000038c",
+      "address": "0x8167A1117691f39e05e9131cfA88F0e3A620E967",
+      "poolType": "Weighted",
+      "symbol": "20WETH-80T",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+          "weight": "0.8",
+          "symbol": "T"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcdf7028ceab81fa0c6971208e83fa7872994bee5.png"
+    }
+  },
+  {
+    "address": "0x63E3951212cCCAFE3eDC7588FD4D20Ee5e7Ad73f",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1670269367,
+    "pool": {
+      "id": "0x5512a4bbe7b3051f92324bacf25c02b9000c4a500001000000000000000003d7",
+      "address": "0x5512A4bbe7B3051f92324bAcF25C02b9000c4a50",
+      "poolType": "Weighted",
+      "symbol": "33LUSD-33LQTY-33WETH",
+      "tokens": [
+        {
+          "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+          "weight": "0.3333",
+          "symbol": "LUSD"
+        },
+        {
+          "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+          "weight": "0.3333",
+          "symbol": "LQTY"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.3334",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+      "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x5f2c3422a675860f0e019Ddd78C6fA681bE84bd4",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1670269367,
+    "pool": {
+      "id": "0xd1ec5e215e8148d76f4460e4097fd3d5ae0a35580002000000000000000003d3",
+      "address": "0xD1eC5e215E8148D76F4460e4097FD3d5ae0A3558",
+      "poolType": "Weighted",
+      "symbol": "50OHM-50WETH",
+      "tokens": [
+        {
+          "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+          "weight": "0.5",
+          "symbol": "OHM"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x107A2209883621aFe2968da31C03190e0B2782C2",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1670269367,
+    "pool": {
+      "id": "0x76fcf0e8c7ff37a47a799fa2cd4c13cde0d981c90002000000000000000003d2",
+      "address": "0x76FCf0e8C7Ff37A47a799FA2cd4c13cDe0D981C9",
+      "poolType": "Weighted",
+      "symbol": "50OHM-50DAI",
+      "tokens": [
+        {
+          "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+          "weight": "0.5",
+          "symbol": "OHM"
+        },
+        {
+          "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "weight": "0.5",
+          "symbol": "DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    }
+  },
+  {
+    "address": "0x01A9502C11f411b494c62746D37e89d6f7078657",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1673913107,
+    "pool": {
+      "id": "0x9c6d47ff73e0f5e51be5fd53236e3f595c5793f200020000000000000000042c",
+      "address": "0x9c6d47Ff73e0F5E51BE5FD53236e3F595C5793F2",
+      "poolType": "MetaStable",
+      "symbol": "B-cbETH-wstETH-Stable",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
+          "weight": "null",
+          "symbol": "cbETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbe9895146f7af43049ca1c1ae358b0541ea49704.png"
+    }
+  },
+  {
+    "address": "0xBC02eF87f4E15EF78A571f3B2aDcC726Fee70d8b",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1673913107,
+    "pool": {
+      "id": "0xff4ce5aaab5a627bf82f4a571ab1ce94aa365ea6000200000000000000000426",
+      "address": "0xFf4ce5AAAb5a627bf82f4A571AB1cE94Aa365eA6",
+      "poolType": "Stable",
+      "symbol": "DOLA-USDC BSP",
+      "tokens": [
+        {
+          "address": "0x865377367054516e17014CcdED1e7d814EDC9ce4",
+          "weight": "null",
+          "symbol": "DOLA"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "null",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x865377367054516e17014CcdED1e7d814EDC9ce4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x865377367054516e17014ccded1e7d814edc9ce4.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0x81C452E84B103555C2Dd2DEc0bFABC0c4d6B3065",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1673913107,
+    "pool": {
+      "id": "0xd590931466cdd6d488a25da1e89dd0539723800c00020000000000000000042b",
+      "address": "0xd590931466cdD6d488A25da1E89dD0539723800c",
+      "poolType": "Weighted",
+      "symbol": "50RBN-50USDC",
+      "tokens": [
+        {
+          "address": "0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
+          "weight": "0.5",
+          "symbol": "RBN"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.5",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6123B0049F904d730dB3C36a31167D9d4121fA6B": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6123b0049f904d730db3c36a31167d9d4121fa6b.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0x4dC35eC8562596ddA6aEe8EceE59a76D4d72b83E",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1675955387,
+    "pool": {
+      "id": "0xdb0cbcf1b8282dedc90e8c2cefe11041d6d1e9f0000200000000000000000431",
+      "address": "0xDb0cBcF1b8282dedc90e8c2CEFe11041d6d1e9f0",
+      "poolType": "Weighted",
+      "symbol": "50SD-50USDC",
+      "tokens": [
+        {
+          "address": "0x30D20208d987713f46DFD34EF128Bb16C404D10f",
+          "weight": "0.5",
+          "symbol": "SD"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.5",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x30D20208d987713f46DFD34EF128Bb16C404D10f": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x30d20208d987713f46dfd34ef128bb16c404d10f.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0x37eCa8DaaB052E722e3bf8ca861aa4e1C047143b",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1675955387,
+    "pool": {
+      "id": "0xe4010ef5e37dc23154680f23c4a0d48bfca91687000200000000000000000432",
+      "address": "0xE4010EF5E37dc23154680f23c4A0d48BFca91687",
+      "poolType": "Weighted",
+      "symbol": "80SD-20WETH",
+      "tokens": [
+        {
+          "address": "0x30D20208d987713f46DFD34EF128Bb16C404D10f",
+          "weight": "0.8",
+          "symbol": "SD"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x30D20208d987713f46DFD34EF128Bb16C404D10f": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x30d20208d987713f46dfd34ef128bb16c404d10f.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x10a361766e64D7983a97202ac3a0F4cee06Eb717",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1675955387,
+    "pool": {
+      "id": "0xb08885e6026bab4333a80024ec25a1a3e1ff2b8a000200000000000000000445",
+      "address": "0xB08885e6026bab4333A80024Ec25a1a3e1FF2b8A",
+      "poolType": "MetaStable",
+      "symbol": "B-staFiETH-WETH-Stable",
+      "tokens": [
+        {
+          "address": "0x9559Aaa82d9649C7A7b220E7c461d2E74c9a3593",
+          "weight": "null",
+          "symbol": "rETH"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x9559Aaa82d9649C7A7b220E7c461d2E74c9a3593": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9559aaa82d9649c7a7b220e7c461d2e74c9a3593.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xFc4541437265945F13368F9F61c19dA427D41A02",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1675955387,
+    "pool": {
+      "id": "0x384f67aa430376efc4f8987eabf7f3f84eb9ea5d00020000000000000000043d",
+      "address": "0x384F67aA430376efc4f8987eaBf7F3f84eB9EA5d",
+      "poolType": "Stable",
+      "symbol": "DOLA-CUSD BSP",
+      "tokens": [
+        {
+          "address": "0x865377367054516e17014CcdED1e7d814EDC9ce4",
+          "weight": "null",
+          "symbol": "DOLA"
+        },
+        {
+          "address": "0xC285B7E09A4584D027E5BC36571785B515898246",
+          "weight": "null",
+          "symbol": "CUSD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x865377367054516e17014CcdED1e7d814EDC9ce4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x865377367054516e17014ccded1e7d814edc9ce4.png",
+      "0xC285B7E09A4584D027E5BC36571785B515898246": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc285b7e09a4584d027e5bc36571785b515898246.png"
+    }
+  },
+  {
+    "address": "0xE629c43BCad1029E12ED51432B9dd3432b656cc9",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1675955387,
+    "pool": {
+      "id": "0xad0e5e0778cac28f1ff459602b31351871b5754a0002000000000000000003ce",
+      "address": "0xAd0e5e0778cAC28f1ff459602b31351871B5754a",
+      "poolType": "FX",
+      "symbol": "BPT",
+      "tokens": [
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "null",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xdB25f211AB05b1c97D595516F45794528a807ad8",
+          "weight": "null",
+          "symbol": "EURS"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+      "0xdB25f211AB05b1c97D595516F45794528a807ad8": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdB25f211AB05b1c97D595516F45794528a807ad8/logo.png"
+    }
+  },
+  {
+    "address": "0x4532fBa326D853A03644758B8B7438374F6780dC",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0xa3c500969accb3d8df08cba313c120818fe0ed9d000200000000000000000471",
+      "address": "0xa3C500969accb3D8DF08CBa313C120818fE0ed9D",
+      "poolType": "Weighted",
+      "symbol": "50SYN-50WETH",
+      "tokens": [
+        {
+          "address": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
+          "weight": "0.5",
+          "symbol": "SYN"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0f2d719407fdbeff09d87557abb7232601fd9f29.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xe9866B9dc2c1213433f614CbB22EdAA0FAFF9a66",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0x831261f44931b7da8ba0dcc547223c60bb75b47f000200000000000000000460",
+      "address": "0x831261f44931B7dA8ba0DcC547223c60BB75B47F",
+      "poolType": "MetaStable",
+      "symbol": "B-wUSDR-STABLE",
+      "tokens": [
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "null",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xD5a14081a34d256711B02BbEf17E567da48E80b5",
+          "weight": "null",
+          "symbol": "wUSDR"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+      "0xD5a14081a34d256711B02BbEf17E567da48E80b5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd5a14081a34d256711b02bbef17e567da48e80b5.png"
+    }
+  },
+  {
+    "address": "0x190AE1f6EE5c0B7bc193fA9CD9bBe9b335F69C65",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0xfd1cf6fd41f229ca86ada0584c63c49c3d66bbc9000200000000000000000438",
+      "address": "0xFD1Cf6FD41F229Ca86ada0584c63C49C3d66BbC9",
+      "poolType": "Weighted",
+      "symbol": "50PENDLE-50WETH",
+      "tokens": [
+        {
+          "address": "0x808507121B80c02388fAd14726482e061B8da827",
+          "weight": "0.5",
+          "symbol": "PENDLE"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x808507121B80c02388fAd14726482e061B8da827": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x808507121b80c02388fad14726482e061b8da827.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0xA2a9Ebd6f4dEA4802083F2C8D08066A4e695e64B",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0x5aee1e99fe86960377de9f88689616916d5dcabe000000000000000000000467",
+      "address": "0x5aEe1e99fE86960377DE9f88689616916D5DcaBe",
+      "poolType": "ComposableStable",
+      "symbol": "wstETH-rETH-sfrxETH-BPT",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xac3E018457B222d93114458476f3E3416Abbe38F",
+          "weight": "null",
+          "symbol": "sfrxETH"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xac3E018457B222d93114458476f3E3416Abbe38F": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xac3e018457b222d93114458476f3e3416abbe38f.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0x2C2179abce3413E27BDA6917f60ae37F96D01826",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0x9f9d900462492d4c21e9523ca95a7cd86142f298000200000000000000000462",
+      "address": "0x9F9d900462492D4C21e9523ca95A7CD86142F298",
+      "poolType": "Weighted",
+      "symbol": "50rETH-50RPL",
+      "tokens": [
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "0.5",
+          "symbol": "rETH"
+        },
+        {
+          "address": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
+          "weight": "0.5",
+          "symbol": "RPL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+      "0xD33526068D116cE69F19A9ee46F0bd304F21A51f": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd33526068d116ce69f19a9ee46f0bd304f21a51f.png"
+    }
+  },
+  {
+    "address": "0x87012b0C3257423fD74a5986F81a0f1954C17a1d",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0x1ee442b5326009bb18f2f472d3e0061513d1a0ff000200000000000000000464",
+      "address": "0x1ee442b5326009Bb18F2F472d3e0061513d1A0fF",
+      "poolType": "Weighted",
+      "symbol": "50rETH-50BADGER",
+      "tokens": [
+        {
+          "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
+          "weight": "0.5",
+          "symbol": "BADGER"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "0.5",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3472A5A71965499acd81997a54BBA8D852C6E53d": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3472A5A71965499acd81997a54BBA8D852C6E53d/logo.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0x95201B61EF19C867dA0D093DF20021e1a559452c",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0x5f1f4e50ba51d723f12385a8a9606afc3a0555f5000200000000000000000465",
+      "address": "0x5f1f4E50ba51D723F12385a8a9606afc3A0555f5",
+      "poolType": "Weighted",
+      "symbol": "50wstETH-50LDO",
+      "tokens": [
+        {
+          "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+          "weight": "0.5",
+          "symbol": "LDO"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5a98fcbea516cf06857215779fd812ca3bef1b32.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0x623F3Dbc761B46F64aE7951700Dd7724cB7d6075",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0x4fd4687ec38220f805b6363c3c1e52d0df3b5023000200000000000000000473",
+      "address": "0x4fD4687ec38220F805b6363C3c1E52D0dF3B5023",
+      "poolType": "Weighted",
+      "symbol": "50wstETH-50bb-euler-USD",
+      "tokens": [
+        {
+          "address": "0x50Cf90B954958480b8DF7958A9E965752F627124",
+          "weight": "0.5",
+          "symbol": "bb-euler-USD-BPT"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x50Cf90B954958480b8DF7958A9E965752F627124": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x50cf90b954958480b8df7958a9e965752f627124.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0x38727B907046818135c9a865D5C40BE6cd1c0514",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0xa718042e5622099e5f0ace4e7122058ab39e1bbe000200000000000000000475",
+      "address": "0xa718042E5622099E5F0aCe4E7122058ab39e1bbe",
+      "poolType": "Weighted",
+      "symbol": "50TEMPLE-50bb-euler-USD",
+      "tokens": [
+        {
+          "address": "0x470EBf5f030Ed85Fc1ed4C2d36B9DD02e77CF1b7",
+          "weight": "0.5",
+          "symbol": "TEMPLE"
+        },
+        {
+          "address": "0x50Cf90B954958480b8DF7958A9E965752F627124",
+          "weight": "0.5",
+          "symbol": "bb-euler-USD-BPT"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x470EBf5f030Ed85Fc1ed4C2d36B9DD02e77CF1b7": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x470ebf5f030ed85fc1ed4c2d36b9dd02e77cf1b7.png",
+      "0x50Cf90B954958480b8DF7958A9E965752F627124": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x50cf90b954958480b8df7958a9e965752f627124.png"
+    }
+  },
+  {
+    "address": "0xE96924D293b9e2961f9763cA058E389D27341D3d",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0xb5e3de837f869b0248825e0175da73d4e8c3db6b000200000000000000000474",
+      "address": "0xB5E3de837F869B0248825e0175DA73d4E8c3db6B",
+      "poolType": "Weighted",
+      "symbol": "50rETH-50bb-euler-USD",
+      "tokens": [
+        {
+          "address": "0x50Cf90B954958480b8DF7958A9E965752F627124",
+          "weight": "0.5",
+          "symbol": "bb-euler-USD-BPT"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "0.5",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x50Cf90B954958480b8DF7958A9E965752F627124": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x50cf90b954958480b8df7958a9e965752f627124.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0xf7B0751Fea697cf1A541A5f57D11058a8fB794ee",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0x36be1e97ea98ab43b4debf92742517266f5731a3000200000000000000000466",
+      "address": "0x36Be1E97eA98AB43b4dEBf92742517266F5731a3",
+      "poolType": "Weighted",
+      "symbol": "50wstETH-50ACX",
+      "tokens": [
+        {
+          "address": "0x44108f0223A3C3028F5Fe7AEC7f9bb2E66beF82F",
+          "weight": "0.5",
+          "symbol": "ACX"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x44108f0223A3C3028F5Fe7AEC7f9bb2E66beF82F": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0x19A13793af96f534F0027b4b6a3eB699647368e7",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1677002963,
+    "pool": {
+      "id": "0x99c88ad7dc566616548adde8ed3effa730eb6c3400000000000000000000049a",
+      "address": "0x99c88AD7dc566616548adde8ED3eFfa730eB6C34",
+      "poolType": "ComposableStable",
+      "symbol": "bb-g-USD",
+      "tokens": [
+        {
+          "address": "0x4A82b580365Cff9B146281Ab72500957a849ABDC",
+          "weight": "null",
+          "symbol": "bb-g-USDC"
+        },
+        {
+          "address": "0xe03aF00faBe8401560c1FF7d242d622a5b601573",
+          "weight": "null",
+          "symbol": "bb-g-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4A82b580365Cff9B146281Ab72500957a849ABDC": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4a82b580365cff9b146281ab72500957a849abdc.png",
+      "0xe03aF00faBe8401560c1FF7d242d622a5b601573": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe03af00fabe8401560c1ff7d242d622a5b601573.png"
+    }
+  },
+  {
+    "address": "0x36365dA262dB3965Ba2E1C4411409Bf22508e0A1",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1677002963,
+    "pool": {
+      "id": "0x15c1cdacd3da1e1c1304200b1beb080d50bbbc0f00020000000000000000045f",
+      "address": "0x15C1cDAcd3dA1E1C1304200b1bEb080D50BbBc0F",
+      "poolType": "Weighted",
+      "symbol": "50TRYB-50USDC",
+      "tokens": [
+        {
+          "address": "0x2C537E5624e4af88A7ae4060C022609376C8D0EB",
+          "weight": "0.5",
+          "symbol": "TRYB"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.5",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2C537E5624e4af88A7ae4060C022609376C8D0EB": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2C537E5624e4af88A7ae4060C022609376C8D0EB/logo.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0xA9A63971c55c132aF0e6B39a081e604F07f4e234",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1677002963,
+    "pool": {
+      "id": "0x483006684f422a9448023b2382615c57c5ecf18f000000000000000000000488",
+      "address": "0x483006684f422a9448023b2382615C57c5ecF18f",
+      "poolType": "ComposableStable",
+      "symbol": "TUSD-bb-e-USD",
+      "tokens": [
+        {
+          "address": "0x3BB22Fc9033b802F2AC47c18885F63476F158aFC",
+          "weight": "null",
+          "symbol": "bb-a-TUSD"
+        },
+        {
+          "address": "0x50Cf90B954958480b8DF7958A9E965752F627124",
+          "weight": "null",
+          "symbol": "bb-euler-USD-BPT"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3BB22Fc9033b802F2AC47c18885F63476F158aFC": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3bb22fc9033b802f2ac47c18885f63476f158afc.png",
+      "0x50Cf90B954958480b8DF7958A9E965752F627124": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x50cf90b954958480b8df7958a9e965752f627124.png"
+    }
+  },
+  {
+    "address": "0x33BcAa8A390e6DcF2f18AE5fDd9e38fD248219eB",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1677002963,
+    "pool": {
+      "id": "0x60683b05e9a39e3509d8fdb9c959f23170f8a0fa000000000000000000000489",
+      "address": "0x60683B05e9a39E3509D8fdb9C959f23170f8A0fa",
+      "poolType": "ComposableStable",
+      "symbol": "bb-i-USD",
+      "tokens": [
+        {
+          "address": "0x2FF1A9Dbdacd55297452cFD8a4d94724Bc22a5F7",
+          "weight": "null",
+          "symbol": "bb-i-USDT"
+        },
+        {
+          "address": "0xbc0F2372008005471874e426e86CCFae7B4De79d",
+          "weight": "null",
+          "symbol": "bb-i-USDC"
+        },
+        {
+          "address": "0xDbA274B4D04097b90A72b62467d828cEFD708037",
+          "weight": "null",
+          "symbol": "bb-i-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2FF1A9Dbdacd55297452cFD8a4d94724Bc22a5F7": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x2ff1a9dbdacd55297452cfd8a4d94724bc22a5f7.png",
+      "0xbc0F2372008005471874e426e86CCFae7B4De79d": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbc0f2372008005471874e426e86ccfae7b4de79d.png",
+      "0xDbA274B4D04097b90A72b62467d828cEFD708037": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdba274b4d04097b90a72b62467d828cefd708037.png"
+    }
+  },
+  {
+    "address": "0xE879f17910E77c01952b97E4A098B0ED15B6295c",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1677002963,
+    "pool": {
+      "id": "0xd4f79ca0ac83192693bce4699d0c10c66aa6cf0f00020000000000000000047e",
+      "address": "0xd4f79CA0Ac83192693bce4699d0c10C66Aa6Cf0F",
+      "poolType": "Weighted",
+      "symbol": "OHM-wstETH",
+      "tokens": [
+        {
+          "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+          "weight": "0.5",
+          "symbol": "OHM"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0x183D73dA7adC5011EC3C46e33BB50271e59EC976",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1678920275,
+    "pool": {
+      "id": "0xf16aee6a71af1a9bc8f56975a4c2705ca7a782bc0002000000000000000004bb",
+      "address": "0xf16aEe6a71aF1A9Bc8F56975A4c2705ca7A782Bc",
+      "poolType": "Weighted",
+      "symbol": "20WETH-80ALCX",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF",
+          "weight": "0.8",
+          "symbol": "ALCX"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdbdb4d16eda451d0503b854cf79d55697f90c8df.png"
+    }
+  },
+  {
+    "address": "0x254f3a52Ba9e0cac4E32B648d129529622D1A46c",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1680086867,
+    "pool": {
+      "id": "0xcaa052584b462198a5a9356c28bce0634d65f65c0000000000000000000004db",
+      "address": "0xCAa052584b462198A5a9356c28bcE0634D65f65C",
+      "poolType": "ComposableStable",
+      "symbol": "bb-ma2-USD",
+      "tokens": [
+        {
+          "address": "0x159cB00338fB63f263fd6f621Df619cEf71DA954",
+          "weight": "null",
+          "symbol": "bb-ma2-USDC"
+        },
+        {
+          "address": "0x335d1709D4dA9aca59d16328db5Cd4eA66BFe06b",
+          "weight": "null",
+          "symbol": "bb-ma2-DAI"
+        },
+        {
+          "address": "0x7337224D59CB16C2Dc6938CD45A7b2c60C865D6A",
+          "weight": "null",
+          "symbol": "bb-ma2-USDT"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x159cB00338fB63f263fd6f621Df619cEf71DA954": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x159cb00338fb63f263fd6f621df619cef71da954.png",
+      "0x335d1709D4dA9aca59d16328db5Cd4eA66BFe06b": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x335d1709d4da9aca59d16328db5cd4ea66bfe06b.png",
+      "0x7337224D59CB16C2Dc6938CD45A7b2c60C865D6A": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7337224d59cb16c2dc6938cd45a7b2c60c865d6a.png"
+    }
+  },
+  {
+    "address": "0xFd29298041eA355cF7e15652689F2865443C3144",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1680086867,
+    "pool": {
+      "id": "0x779d01f939d78a918a3de18cc236ee89221dfd4e0000000000000000000004c7",
+      "address": "0x779d01F939D78a918A3de18cC236ee89221dfd4E",
+      "poolType": "ComposableStable",
+      "symbol": "bb-s-USD",
+      "tokens": [
+        {
+          "address": "0xbFA413A2ff0F20456d57B643746133F54bFE0cd2",
+          "weight": "null",
+          "symbol": "bb-s-USDC"
+        },
+        {
+          "address": "0xDc063deAfcE952160eC112FA382ac206305657e6",
+          "weight": "null",
+          "symbol": "bb-s-USDT"
+        },
+        {
+          "address": "0xFD11CCdBdb7AB91Cb9427A6d6BF570C95876d195",
+          "weight": "null",
+          "symbol": "bb-s-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xbFA413A2ff0F20456d57B643746133F54bFE0cd2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbfa413a2ff0f20456d57b643746133f54bfe0cd2.png",
+      "0xDc063deAfcE952160eC112FA382ac206305657e6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdc063deafce952160ec112fa382ac206305657e6.png",
+      "0xFD11CCdBdb7AB91Cb9427A6d6BF570C95876d195": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfd11ccdbdb7ab91cb9427a6d6bf570c95876d195.png"
+    }
+  },
+  {
+    "address": "0x6661136537dfDCA26EEA05c8500502d7D5796E5E",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1680633179,
+    "pool": {
+      "id": "0x9cc64ee4cb672bc04c54b00a37e1ed75b2cc19dd0002000000000000000004c1",
+      "address": "0x9CC64EE4CB672Bc04C54B00a37E1Ed75b2Cc19Dd",
+      "poolType": "Weighted",
+      "symbol": "80Silo-20WETH",
+      "tokens": [
+        {
+          "address": "0x6f80310CA7F2C654691D1383149Fa1A57d8AB1f8",
+          "weight": "0.8",
+          "symbol": "Silo"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6f80310CA7F2C654691D1383149Fa1A57d8AB1f8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x5612876e6F6cA370d93873FE28c874e89E741fB9",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1680633179,
+    "pool": {
+      "id": "0x79c58f70905f734641735bc61e45c19dd9ad60bc0000000000000000000004e7",
+      "address": "0x79c58f70905F734641735BC61e45c19dD9Ad60bC",
+      "poolType": "ComposableStable",
+      "symbol": "USDC-DAI-USDT",
+      "tokens": [
+        {
+          "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "weight": "null",
+          "symbol": "DAI"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "null",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "weight": "null",
+          "symbol": "USDT"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    }
+  },
+  {
+    "address": "0x0052688295413b32626D226a205b95cDB337DE86",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1681342871,
+    "pool": {
+      "id": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016000000000000000000000502",
+      "address": "0xfeBb0bbf162E64fb9D0dfe186E517d84C395f016",
+      "poolType": "ComposableStable",
+      "symbol": "bb-a-USD",
+      "tokens": [
+        {
+          "address": "0x6667c6fa9f2b3Fc1Cc8D85320b62703d938E4385",
+          "weight": "null",
+          "symbol": "bb-a-DAI"
+        },
+        {
+          "address": "0xA1697F9Af0875B63DdC472d6EeBADa8C1fAB8568",
+          "weight": "null",
+          "symbol": "bb-a-USDT"
+        },
+        {
+          "address": "0xcbFA4532D8B2ade2C261D3DD5ef2A2284f792692",
+          "weight": "null",
+          "symbol": "bb-a-USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6667c6fa9f2b3Fc1Cc8D85320b62703d938E4385": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6667c6fa9f2b3fc1cc8d85320b62703d938e4385.png",
+      "0xA1697F9Af0875B63DdC472d6EeBADa8C1fAB8568": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa1697f9af0875b63ddc472d6eebada8c1fab8568.png",
+      "0xcbFA4532D8B2ade2C261D3DD5ef2A2284f792692": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcbfa4532d8b2ade2c261d3dd5ef2a2284f792692.png"
+    }
+  },
+  {
+    "address": "0x5f838591A5A8048F0E4C4c7fCca8fD9A25BF0590",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1681342871,
+    "pool": {
+      "id": "0xe0fcbf4d98f0ad982db260f86cf28b49845403c5000000000000000000000504",
+      "address": "0xE0fCBf4d98F0aD982DB260f86cf28b49845403C5",
+      "poolType": "ComposableStable",
+      "symbol": "wstETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x60D604890feaa0b5460B28A424407c24fe89374a",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x60D604890feaa0b5460B28A424407c24fe89374a": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0xCd8bB8cEBc794842967849255C234e7b7619A518",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1681342871,
+    "pool": {
+      "id": "0xd278166dabaf26707362f7cfdd204b277fd2a4600002000000000000000004f6",
+      "address": "0xD278166DAbaf26707362f7CfDd204b277FD2a460",
+      "poolType": "Weighted",
+      "symbol": "50USH-50WETH",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xE60779CC1b2c1d0580611c526a8DF0E3f870EC48",
+          "weight": "0.5",
+          "symbol": "USH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xE60779CC1b2c1d0580611c526a8DF0E3f870EC48": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe60779cc1b2c1d0580611c526a8df0e3f870ec48.png"
+    }
+  },
+  {
+    "address": "0xD9cde95eFeD2d426F2741E2c44De9573116B8F07",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1681342787,
+    "pool": {
+      "id": "0x08775ccb6674d6bdceb0797c364c2653ed84f3840002000000000000000004f0",
+      "address": "0x08775ccb6674d6bDCeB0797C364C2653ED84F384",
+      "poolType": "Weighted",
+      "symbol": "50WETH-50-3pool",
+      "tokens": [
+        {
+          "address": "0x79c58f70905F734641735BC61e45c19dD9Ad60bC",
+          "weight": "0.5",
+          "symbol": "USDC-DAI-USDT"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x79c58f70905F734641735BC61e45c19dD9Ad60bC": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x79c58f70905f734641735bc61e45c19dd9ad60bc.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x454eb2f12242397688DbfdA241487e67ed80507a",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1681342871,
+    "pool": {
+      "id": "0x639883476960a23b38579acfd7d71561a0f408cf000200000000000000000505",
+      "address": "0x639883476960a23b38579acfd7D71561A0f408Cf",
+      "poolType": "Weighted",
+      "symbol": "50STG-50bbaUSD",
+      "tokens": [
+        {
+          "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+          "weight": "0.5",
+          "symbol": "STG"
+        },
+        {
+          "address": "0xfeBb0bbf162E64fb9D0dfe186E517d84C395f016",
+          "weight": "0.5",
+          "symbol": "bb-a-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6.png",
+      "0xfeBb0bbf162E64fb9D0dfe186E517d84C395f016": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfebb0bbf162e64fb9d0dfe186e517d84c395f016.png"
+    }
+  },
+  {
+    "address": "0xF17F1E67bc384E43b4acf69cc032AD086f15f262",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1681342787,
+    "pool": {
+      "id": "0x8bd4a1e74a27182d23b98c10fd21d4fbb0ed4ba00002000000000000000004ed",
+      "address": "0x8Bd4A1E74A27182D23B98c10Fd21D4FbB0eD4BA0",
+      "poolType": "Weighted",
+      "symbol": "50TEMPLE-50DAI",
+      "tokens": [
+        {
+          "address": "0x470EBf5f030Ed85Fc1ed4C2d36B9DD02e77CF1b7",
+          "weight": "0.5",
+          "symbol": "TEMPLE"
+        },
+        {
+          "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "weight": "0.5",
+          "symbol": "DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x470EBf5f030Ed85Fc1ed4C2d36B9DD02e77CF1b7": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x470ebf5f030ed85fc1ed4c2d36b9dd02e77cf1b7.png",
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    }
+  },
+  {
+    "address": "0x70c6A653e273523FADfB4dF99558737906c230c6",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1681887467,
+    "pool": {
+      "id": "0x9001cbbd96f54a658ff4e6e65ab564ded76a543100000000000000000000050a",
+      "address": "0x9001cBbD96F54a658FF4e6E65AB564DED76a5431",
+      "poolType": "ComposableStable",
+      "symbol": "cbETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x60D604890feaa0b5460B28A424407c24fe89374a",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
+          "weight": "null",
+          "symbol": "cbETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x60D604890feaa0b5460B28A424407c24fe89374a": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+      "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbe9895146f7af43049ca1c1ae358b0541ea49704.png"
+    }
+  },
+  {
+    "address": "0x2fC4506354166e8B9183FBB6A68cd9C5F3Fb9Bc5",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1681887467,
+    "pool": {
+      "id": "0x87a867f5d240a782d43d90b6b06dea470f3f8f22000200000000000000000516",
+      "address": "0x87a867f5D240a782d43D90b6B06DEa470F3f8F22",
+      "poolType": "Weighted",
+      "symbol": "B-50COMP-50wstETH",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+          "weight": "0.5",
+          "symbol": "COMP"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xc00e94Cb662C3520282E6f5717214004A7f26888": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    }
+  },
+  {
+    "address": "0xC764B55852F8849Ae69923e45ce077A576bF9a8d",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1681887467,
+    "pool": {
+      "id": "0x04248aabca09e9a1a3d5129a7ba05b7f17de768400000000000000000000050e",
+      "address": "0x04248AAbca09E9a1a3D5129a7ba05b7F17DE7684",
+      "poolType": "ComposableStable",
+      "symbol": "qETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x60D604890feaa0b5460B28A424407c24fe89374a",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0x93ef1Ea305D11A9b2a3EbB9bB4FCc34695292E7d",
+          "weight": "null",
+          "symbol": "qETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x60D604890feaa0b5460B28A424407c24fe89374a": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+      "0x93ef1Ea305D11A9b2a3EbB9bB4FCc34695292E7d": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x93ef1ea305d11a9b2a3ebb9bb4fcc34695292e7d.png"
+    }
+  },
+  {
+    "address": "0x2D42910D826e5500579D121596E98A6eb33C0a1b",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1681887467,
+    "pool": {
+      "id": "0x68e3266c9c8bbd44ad9dca5afbfe629022aee9fe000200000000000000000512",
+      "address": "0x68e3266C9C8bbD44ad9Dca5AFBfe629022AeE9fE",
+      "poolType": "Weighted",
+      "symbol": "B-wjAura-wETH",
+      "tokens": [
+        {
+          "address": "0x198d7387Fa97A73F05b8578CdEFf8F2A1f34Cd1F",
+          "weight": "0.8",
+          "symbol": "wjAURA"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x198d7387Fa97A73F05b8578CdEFf8F2A1f34Cd1F": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x198d7387fa97a73f05b8578cdeff8f2a1f34cd1f.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x11Ff498C7c2A29fc4638BF45D9fF995C3297fcA5",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0x02d928e68d8f10c0358566152677db51e1e2dc8c00000000000000000000051e",
+      "address": "0x02D928E68D8F10C0358566152677Db51E1e2Dc8C",
+      "poolType": "ComposableStable",
+      "symbol": "swETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x60D604890feaa0b5460B28A424407c24fe89374a",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xf951E335afb289353dc249e82926178EaC7DEd78",
+          "weight": "null",
+          "symbol": "swETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x60D604890feaa0b5460B28A424407c24fe89374a": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+      "0xf951E335afb289353dc249e82926178EaC7DEd78": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf951e335afb289353dc249e82926178eac7ded78.png"
+    }
+  },
+  {
+    "address": "0xc85d90dec1E12eDee418C445b381E7168EB380Ab",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0xd689abc77b82803f22c49de5c8a0049cc74d11fd000200000000000000000524",
+      "address": "0xd689ABc77B82803F22c49dE5C8A0049Cc74D11fD",
+      "poolType": "Weighted",
+      "symbol": "80USH-20unshETH",
+      "tokens": [
+        {
+          "address": "0x0Ae38f7E10A43B5b2fB064B42a2f4514cbA909ef",
+          "weight": "0.2",
+          "symbol": "unshETH"
+        },
+        {
+          "address": "0xE60779CC1b2c1d0580611c526a8DF0E3f870EC48",
+          "weight": "0.8",
+          "symbol": "USH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0Ae38f7E10A43B5b2fB064B42a2f4514cbA909ef": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0ae38f7e10a43b5b2fb064b42a2f4514cba909ef.png",
+      "0xE60779CC1b2c1d0580611c526a8DF0E3f870EC48": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe60779cc1b2c1d0580611c526a8df0e3f870ec48.png"
+    }
+  },
+  {
+    "address": "0x78a54C8F4eAba82e45cBC20B9454a83CB296e09E",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683721091,
+    "pool": {
+      "id": "0x42fbd9f666aacc0026ca1b88c94259519e03dd67000200000000000000000507",
+      "address": "0x42FBD9F666AaCC0026ca1B88C94259519e03dd67",
+      "poolType": "Weighted",
+      "symbol": "50COIL-50USDC",
+      "tokens": [
+        {
+          "address": "0x823E1B82cE1Dc147Bbdb25a203f046aFab1CE918",
+          "weight": "0.5",
+          "symbol": "COIL"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.5",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x823E1B82cE1Dc147Bbdb25a203f046aFab1CE918": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x823e1b82ce1dc147bbdb25a203f046afab1ce918.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0x8a88C1f44854C61a466aB55614F6A7778473418b",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1683038387,
+    "pool": {
+      "id": "0x793f2d5cd52dfafe7a1a1b0b3988940ba2d6a63d0000000000000000000004f8",
+      "address": "0x793F2D5Cd52dfafe7a1a1B0B3988940Ba2d6a63D",
+      "poolType": "ComposableStable",
+      "symbol": "B-vETH-STABLE",
+      "tokens": [
+        {
+          "address": "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F",
+          "weight": "null",
+          "symbol": "vETH"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4bc3263eb5bb2ef7ad9ab6fb68be80e43b43801f.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x5aF3B93Fb82ab8691b82a09CBBae7b8D3eB5Ac11",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683038387,
+    "pool": {
+      "id": "0x7e9afd25f5ec0eb24d7d4b089ae7ecb9651c8b1f000000000000000000000511",
+      "address": "0x7E9AfD25F5Ec0eb24d7d4b089Ae7EcB9651c8b1F",
+      "poolType": "ComposableStable",
+      "symbol": "B-baoUSD-LUSD-BPT",
+      "tokens": [
+        {
+          "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+          "weight": "null",
+          "symbol": "LUSD"
+        },
+        {
+          "address": "0x7945b0A6674b175695e5d1D08aE1e6F13744Abb0",
+          "weight": "null",
+          "symbol": "BaoUSD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+      "0x7945b0A6674b175695e5d1D08aE1e6F13744Abb0": "https://assets.coingecko.com/coins/images/28592/large/baoUSD.png?1672191676"
+    }
+  },
+  {
+    "address": "0xd1c070eBc7Ec77f2134b3Ef75283b6C1fb31a157",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683721091,
+    "pool": {
+      "id": "0x2e848426aec6dbf2260535a5bea048ed94d9ff3d000000000000000000000536",
+      "address": "0x2E848426AEc6dbF2260535a5bEa048ed94d9FF3D",
+      "poolType": "ComposableStable",
+      "symbol": "wbETH-wstETH",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xa2E3356610840701BDf5611a53974510Ae27E2e1",
+          "weight": "null",
+          "symbol": "wBETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xa2E3356610840701BDf5611a53974510Ae27E2e1": "https://assets.coingecko.com/coins/images/30061/large/wbeth-icon.png?1683001548"
+    }
+  },
+  {
+    "address": "0x69F1077AeCE23D5b0344330B5eB13f05d5e410a1",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1684791827,
+    "pool": {
+      "id": "0xdf2c03c12442c7a0895455a48569b889079ca52a000200000000000000000538",
+      "address": "0xDf2c03c12442c7A0895455A48569B889079cA52A",
+      "poolType": "Weighted",
+      "symbol": "80ARCH-20WETH",
+      "tokens": [
+        {
+          "address": "0x73C69d24ad28e2d43D03CBf35F79fE26EBDE1011",
+          "weight": "0.8",
+          "symbol": "ARCH"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x73C69d24ad28e2d43D03CBf35F79fE26EBDE1011": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x73c69d24ad28e2d43d03cbf35f79fe26ebde1011.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x6E7B9A1746a7eD4b23edFf0975B726E5aA673E21",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1685385851,
+    "pool": {
+      "id": "0x380aabe019ed2a9c2d632b51eddd30fd804d0fad000200000000000000000554",
+      "address": "0x380aAbE019ed2a9C2d632b51eDDD30fd804d0fAD",
+      "poolType": "Weighted",
+      "symbol": "50R-50wstETH",
+      "tokens": [
+        {
+          "address": "0x183015a9bA6fF60230fdEaDc3F43b3D788b13e21",
+          "weight": "0.5",
+          "symbol": "R"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x183015a9bA6fF60230fdEaDc3F43b3D788b13e21": "https://assets.coingecko.com/coins/images/29551/large/R_logo_CMC.png?1679621963",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0x6F3b31296FD2457eba6Dca3BED65ec79e06c1295",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1685385851,
+    "pool": {
+      "id": "0x20a61b948e33879ce7f23e535cc7baa3bc66c5a9000000000000000000000555",
+      "address": "0x20a61B948E33879ce7F23e535CC7BAA3BC66c5a9",
+      "poolType": "ComposableStable",
+      "symbol": "R-DAI-BLP",
+      "tokens": [
+        {
+          "address": "0x183015a9bA6fF60230fdEaDc3F43b3D788b13e21",
+          "weight": "null",
+          "symbol": "R"
+        },
+        {
+          "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "weight": "null",
+          "symbol": "DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x183015a9bA6fF60230fdEaDc3F43b3D788b13e21": "https://assets.coingecko.com/coins/images/29551/large/R_logo_CMC.png?1679621963",
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    }
+  },
+  {
+    "address": "0xFa58735ceEAa83a7c9c13CA771F12378D40D7b05",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1685385851,
+    "pool": {
+      "id": "0xfcf77141908aa22bfeac216123c5feb2531f373e00000000000000000000054a",
+      "address": "0xFCF77141908Aa22bfEAc216123C5FEb2531f373e",
+      "poolType": "ComposableStable",
+      "symbol": "B-rETH-swETH-STABLE",
+      "tokens": [
+        {
+          "address": "0x304A2050dF259DCA35335C90CE983AdC5f2Dc50C",
+          "weight": "null",
+          "symbol": "sWETH"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x304A2050dF259DCA35335C90CE983AdC5f2Dc50C": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x304a2050df259dca35335c90ce983adc5f2dc50c.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0xbf65b3fA6c208762eD74e82d4AEfCDDfd0323648",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1686141695,
+    "pool": {
+      "id": "0xdfe6e7e18f6cc65fa13c8d8966013d4fda74b6ba000000000000000000000558",
+      "address": "0xdfE6e7e18f6Cc65FA13C8D8966013d4FdA74b6ba",
+      "poolType": "ComposableStable",
+      "symbol": "ankrETH/wstETH",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb",
+          "weight": "null",
+          "symbol": "ankrETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb.png"
+    }
+  },
+  {
+    "address": "0xD449Efa0A587f2cb6BE3AE577Bc167a774525810",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1686659711,
+    "pool": {
+      "id": "0x1a44e35d5451e0b78621a1b3e7a53dfaa306b1d000000000000000000000051b",
+      "address": "0x1A44E35d5451E0b78621A1B3e7a53DFaA306B1D0",
+      "poolType": "ComposableStable",
+      "symbol": "B-baoETH-ETH-BPT",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xf4edfad26EE0D23B69CA93112eccE52704E0006f",
+          "weight": "null",
+          "symbol": "baoETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xf4edfad26EE0D23B69CA93112eccE52704E0006f": ""
+    }
+  },
+  {
+    "address": "0xd8191A3496a1520c2B5C81D04B26F8556Fc62d7b",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1686659711,
+    "pool": {
+      "id": "0x18fdf15ff782e44c1f9b6c5846ff6b0f0004f6a2000200000000000000000560",
+      "address": "0x18FDf15ff782e44C1f9B6C5846ff6B0F0004F6a2",
+      "poolType": "Weighted",
+      "symbol": "50OHM-50LUSD",
+      "tokens": [
+        {
+          "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+          "weight": "0.5",
+          "symbol": "LUSD"
+        },
+        {
+          "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+          "weight": "0.5",
+          "symbol": "OHM"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+      "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png"
+    }
+  },
+  {
+    "address": "0x9fB7D6dCAC7b6aa20108BaD226c35B85A9e31B63",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0x481c5fc05d63a58aa2f0f2aa417c021b5d419cb200000000000000000000056a",
+      "address": "0x481C5fc05D63a58AA2f0F2aA417C021B5d419cB2",
+      "poolType": "ComposableStable",
+      "symbol": "rETH/bbaWETH BPT",
+      "tokens": [
+        {
+          "address": "0x60D604890feaa0b5460B28A424407c24fe89374a",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x60D604890feaa0b5460B28A424407c24fe89374a": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0xD3D5d45f4Edf82ba0dFaf061d230766032a10e07",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0x26c2b83fc8535deead276f5cc3ad9c1a2192e02700020000000000000000056b",
+      "address": "0x26c2B83FC8535DeEaD276f5Cc3ad9c1a2192E027",
+      "poolType": "Weighted",
+      "symbol": "OHM/bbaDAI BPT",
+      "tokens": [
+        {
+          "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+          "weight": "0.5",
+          "symbol": "OHM"
+        },
+        {
+          "address": "0x6667c6fa9f2b3Fc1Cc8D85320b62703d938E4385",
+          "weight": "0.5",
+          "symbol": "bb-a-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+      "0x6667c6fa9f2b3Fc1Cc8D85320b62703d938E4385": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6667c6fa9f2b3fc1cc8d85320b62703d938e4385.png"
+    }
+  },
+  {
+    "address": "0x8eeB783A4A67f626c6E3952AAeD0D6b104AaC85f",
+    "network": 1,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0xc5dc1316ab670a2eed5716d7f19ced321191f38200000000000000000000056e",
+      "address": "0xC5DC1316AB670a2eeD5716d7F19CeD321191F382",
+      "poolType": "ComposableStable",
+      "symbol": "B-wstETH/bb-ma3-weth",
+      "tokens": [
+        {
+          "address": "0x3fCb7085B8F2F473F80bF6D879cAe99eA4DE9344",
+          "weight": "null",
+          "symbol": "bb-ma3-weth"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3fCb7085B8F2F473F80bF6D879cAe99eA4DE9344": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3fcb7085b8f2f473f80bf6d879cae99ea4de9344.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0x6AF7bCA454f3C8165225Ed46FD4d78cc90E81fAA",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1687806647,
+    "pool": {
+      "id": "0xbfce47224b4a938865e3e2727dc34e0faa5b1d82000000000000000000000527",
+      "address": "0xbFCe47224B4A938865E3e2727DC34E0fAA5b1D82",
+      "poolType": "ComposableStable",
+      "symbol": "uniETH-WETH",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4",
+          "weight": "null",
+          "symbol": "uniETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf1376bcef0f78459c0ed0ba5ddce976f1ddf51f4.png"
+    }
+  },
+  {
+    "address": "0x1d157Cf1F1339864A3C291D1Bbe786d6Ee682434",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1687806647,
+    "pool": {
+      "id": "0x156c02f3f7fef64a3a9d80ccf7085f23cce91d76000000000000000000000570",
+      "address": "0x156C02f3f7fEf64a3A9D80CCF7085f23ccE91D76",
+      "poolType": "ComposableStable",
+      "symbol": "vETH/WETH BPT",
+      "tokens": [
+        {
+          "address": "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F",
+          "weight": "null",
+          "symbol": "vETH"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4bc3263eb5bb2ef7ad9ab6fb68be80e43b43801f.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x39dF6e857bdf7387273C43eBb373b9D74F467d35",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687806647,
+    "pool": {
+      "id": "0x9d7f992c900fbea0ec314bdd71b7cc1becf76a33000200000000000000000573",
+      "address": "0x9d7f992c900FbeA0EC314Bdd71b7cC1becF76A33",
+      "poolType": "Weighted",
+      "symbol": "50OHM/50bbaWETH",
+      "tokens": [
+        {
+          "address": "0x60D604890feaa0b5460B28A424407c24fe89374a",
+          "weight": "0.5",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+          "weight": "0.5",
+          "symbol": "OHM"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x60D604890feaa0b5460B28A424407c24fe89374a": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+      "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png"
+    }
+  },
+  {
+    "address": "0x9e3f4FB69058244066801404e50889592d33cA11",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x4cbde5c4b4b53ebe4af4adb85404725985406163000000000000000000000595",
+      "address": "0x4CbdE5C4B4B53EBE4aF4adB85404725985406163",
+      "poolType": "ComposableStable",
+      "symbol": "B-ETHx/bb-a-WETH ",
+      "tokens": [
+        {
+          "address": "0xA35b1B31Ce002FBF2058D22F30f95D405200A15b",
+          "weight": "null",
+          "symbol": "ETHx"
+        },
+        {
+          "address": "0xbB6881874825E60e1160416D6C426eae65f2459E",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xA35b1B31Ce002FBF2058D22F30f95D405200A15b": "https://assets.coingecko.com/coins/images/30870/large/ETHx-small.png?1688373266",
+      "0xbB6881874825E60e1160416D6C426eae65f2459E": ""
+    }
+  },
+  {
+    "address": "0x882f961Def46deadAcf31798B295834a5b6d0c86",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xbf2ef8bdc2fc0f3203b3a01778e3ec5009aeef3300000000000000000000058d",
+      "address": "0xbF2ef8bDC2fC0F3203B3a01778E3ec5009AEEf33",
+      "poolType": "ComposableStable",
+      "symbol": "R-bb-s-DAI-BLP",
+      "tokens": [
+        {
+          "address": "0x183015a9bA6fF60230fdEaDc3F43b3D788b13e21",
+          "weight": "null",
+          "symbol": "R"
+        },
+        {
+          "address": "0x2B218683178d029BAB6c9789b1073aA6c96E5176",
+          "weight": "null",
+          "symbol": "bb-s-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x183015a9bA6fF60230fdEaDc3F43b3D788b13e21": "https://assets.coingecko.com/coins/images/29551/large/R_logo_CMC.png?1679621963",
+      "0x2B218683178d029BAB6c9789b1073aA6c96E5176": ""
+    }
+  },
+  {
+    "address": "0x70892E4355d0E04A3d19264E93c64C401520f3A4",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x3fa8c89704e5d07565444009e5d9e624b40be813000000000000000000000599",
+      "address": "0x3FA8C89704e5d07565444009e5d9e624B40Be813",
+      "poolType": "ComposableStable",
+      "symbol": "GHO/LUSD",
+      "tokens": [
+        {
+          "address": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+          "weight": "null",
+          "symbol": "GHO"
+        },
+        {
+          "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+          "weight": "null",
+          "symbol": "LUSD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f/logo.png",
+      "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png"
+    }
+  },
+  {
+    "address": "0x6EE63656BbF5BE3fdF9Be4982BF9466F6a921b83",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x7d98f308db99fdd04bbf4217a4be8809f38faa6400020000000000000000059b",
+      "address": "0x7D98f308Db99FDD04BbF4217a4be8809F38fAa64",
+      "poolType": "Weighted",
+      "symbol": "80wstETH/20GHO",
+      "tokens": [
+        {
+          "address": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+          "weight": "0.2",
+          "symbol": "GHO"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "0.8",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f/logo.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0x73f49a29F91e016CC9BdE5cdF6f5DC049280e5A9",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xb2b918f2d628b4c8ff237b0a1c6ac3bea222fedc00020000000000000000059c",
+      "address": "0xB2B918f2d628b4c8ff237b0A1c6aC3Bea222FEDc",
+      "poolType": "Weighted",
+      "symbol": "50GHO/50OHM",
+      "tokens": [
+        {
+          "address": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+          "weight": "0.5",
+          "symbol": "GHO"
+        },
+        {
+          "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+          "weight": "0.5",
+          "symbol": "OHM"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f/logo.png",
+      "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png"
+    }
+  },
+  {
+    "address": "0x5Db1Fe5A1652f095eBc3f6065E9DB3f3d492bfC2",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xc2b021133d1b0cf07dba696fd5dd89338428225b000000000000000000000598",
+      "address": "0xc2B021133D1b0cF07dba696fd5DD89338428225B",
+      "poolType": "ComposableStable",
+      "symbol": "GHO/bb-a-USD",
+      "tokens": [
+        {
+          "address": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+          "weight": "null",
+          "symbol": "GHO"
+        },
+        {
+          "address": "0xc443C15033FCB6Cf72cC24f1BDA0Db070DdD9786",
+          "weight": "null",
+          "symbol": "bb-a-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f/logo.png",
+      "0xc443C15033FCB6Cf72cC24f1BDA0Db070DdD9786": "https://assets.coingecko.com/coins/images/25769/large/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2.png?1653604699"
+    }
+  },
+  {
+    "address": "0x5c23661E747F84E0c71d782e5f1513126041734B",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x9a172e1cb0e99f7e6dcc4c52e4655e8f337d5c0000000000000000000000059a",
+      "address": "0x9A172e1cb0E99f7E6DCc4c52e4655e8f337d5c00",
+      "poolType": "ComposableStable",
+      "symbol": "GHO/MAI",
+      "tokens": [
+        {
+          "address": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+          "weight": "null",
+          "symbol": "GHO"
+        },
+        {
+          "address": "0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6",
+          "weight": "null",
+          "symbol": "MAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f/logo.png",
+      "0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x8d6cebd76f18e1558d4db88138e2defb3909fad6.png"
+    }
+  },
+  {
+    "address": "0x0021e01B9fAb840567a8291b864fF783894EabC6",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x42ed016f826165c2e5976fe5bc3df540c5ad0af700000000000000000000058b",
+      "address": "0x42ED016F826165C2e5976fe5bC3df540C5aD0Af7",
+      "poolType": "ComposableStable",
+      "symbol": "wstETH-rETH-sfrxETH-BPT",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xac3E018457B222d93114458476f3E3416Abbe38F",
+          "weight": "null",
+          "symbol": "sfrxETH"
+        },
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xac3E018457B222d93114458476f3E3416Abbe38F": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xac3e018457b222d93114458476f3e3416abbe38f.png",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png"
+    }
+  },
+  {
+    "address": "0x21eC388000B5BA5D9e3DF3848EA0c1f58e054Af7",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xc443c15033fcb6cf72cc24f1bda0db070ddd9786000000000000000000000593",
+      "address": "0xc443C15033FCB6Cf72cC24f1BDA0Db070DdD9786",
+      "poolType": "ComposableStable",
+      "symbol": "bb-a-USD",
+      "tokens": [
+        {
+          "address": "0xc50d4347209F285247BDa8A09Fc1C12CE42031c3",
+          "weight": "null",
+          "symbol": "bb-a-USDC"
+        },
+        {
+          "address": "0xcfAE6E251369467F465f13836Ac8135bd42f8A56",
+          "weight": "null",
+          "symbol": "bb-a-USDT"
+        },
+        {
+          "address": "0xfa24A90A3F2bBE5FEEA92B95cD0d14Ce709649f9",
+          "weight": "null",
+          "symbol": "bb-a-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xc50d4347209F285247BDa8A09Fc1C12CE42031c3": "",
+      "0xcfAE6E251369467F465f13836Ac8135bd42f8A56": "",
+      "0xfa24A90A3F2bBE5FEEA92B95cD0d14Ce709649f9": ""
+    }
+  },
+  {
+    "address": "0x29488df9253171AcD0a0598FDdA92C5F6E767a38",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x41503c9d499ddbd1dcdf818a1b05e9774203bf46000000000000000000000594",
+      "address": "0x41503C9D499ddbd1dCdf818a1b05e9774203Bf46",
+      "poolType": "ComposableStable",
+      "symbol": "wstETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xbB6881874825E60e1160416D6C426eae65f2459E",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+      "0xbB6881874825E60e1160416D6C426eae65f2459E": ""
+    }
+  },
+  {
+    "address": "0x3eFd3E18504dC213188Ed2b694F886A305a6e5ed",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xd7edb56f63b2a0191742aea32df1f98ca81ed9c600000000000000000000058e",
+      "address": "0xd7edb56F63b2a0191742aEa32DF1F98ca81ed9c6",
+      "poolType": "ComposableStable",
+      "symbol": "B-wstETH/bb-ma3-weth",
+      "tokens": [
+        {
+          "address": "0x3fCb7085B8F2F473F80bF6D879cAe99eA4DE9344",
+          "weight": "null",
+          "symbol": "bb-ma3-weth"
+        },
+        {
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "weight": "null",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3fCb7085B8F2F473F80bF6D879cAe99eA4DE9344": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3fcb7085b8f2f473f80bf6d879cae99ea4de9344.png",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+    }
+  },
+  {
+    "address": "0xE35f0152f0d49fE8E386E5c42B656321ffB0d477",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x9b692f571b256140a39a34676bffa30634c586e100000000000000000000059d",
+      "address": "0x9B692f571b256140a39a34676BffA30634c586e1",
+      "poolType": "ComposableStable",
+      "symbol": "bb-i-USD",
+      "tokens": [
+        {
+          "address": "0x2FF1A9Dbdacd55297452cFD8a4d94724Bc22a5F7",
+          "weight": "null",
+          "symbol": "bb-i-USDT"
+        },
+        {
+          "address": "0xbc0F2372008005471874e426e86CCFae7B4De79d",
+          "weight": "null",
+          "symbol": "bb-i-USDC"
+        },
+        {
+          "address": "0xDbA274B4D04097b90A72b62467d828cEFD708037",
+          "weight": "null",
+          "symbol": "bb-i-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2FF1A9Dbdacd55297452cFD8a4d94724Bc22a5F7": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x2ff1a9dbdacd55297452cfd8a4d94724bc22a5f7.png",
+      "0xbc0F2372008005471874e426e86CCFae7B4De79d": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbc0f2372008005471874e426e86ccfae7b4de79d.png",
+      "0xDbA274B4D04097b90A72b62467d828cEFD708037": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdba274b4d04097b90a72b62467d828cefd708037.png"
+    }
+  },
+  {
+    "address": "0xe77D45b5dE97aC7717E4EdE6bE16E3D805fF02A5",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xdd59f89b5b07b7844d72996fc9d83d81acc8219600000000000000000000059e",
+      "address": "0xdD59f89B5B07B7844d72996fC9d83D81acC82196",
+      "poolType": "ComposableStable",
+      "symbol": "uniETH-WETH",
+      "tokens": [
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4",
+          "weight": "null",
+          "symbol": "uniETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf1376bcef0f78459c0ed0ba5ddce976f1ddf51f4.png"
+    }
+  },
+  {
+    "address": "0x0A4825154bCFD493d15777184d01B93e8115215a",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xb54e6aadbf1ac1a3ef2a56e358706f0f8e320a0300000000000000000000059f",
+      "address": "0xB54E6AADBF1ac1a3EF2A56E358706F0f8E320a03",
+      "poolType": "ComposableStable",
+      "symbol": "vETH/WETH BPT",
+      "tokens": [
+        {
+          "address": "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F",
+          "weight": "null",
+          "symbol": "vETH"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4bc3263eb5bb2ef7ad9ab6fb68be80e43b43801f.png",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x6d5AF3414a73E498039a3720aFb4A376aE9C5a07",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x4c81255cc9ed7062180ea99962fe05ac0d57350b0000000000000000000005a3",
+      "address": "0x4C81255Cc9eD7062180ea99962fE05aC0D57350B",
+      "poolType": "ComposableStable",
+      "symbol": "cbETH-bb-a-WETH-BPT ",
+      "tokens": [
+        {
+          "address": "0xbB6881874825E60e1160416D6C426eae65f2459E",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
+          "weight": "null",
+          "symbol": "cbETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xbB6881874825E60e1160416D6C426eae65f2459E": "",
+      "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbe9895146f7af43049ca1c1ae358b0541ea49704.png"
+    }
+  },
+  {
+    "address": "0x06d27c0FE5AbF6020bf56E47c72Ca002dD5d9f54",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x1bd2f176a812e312077bca87e37c08432bb09f3e0000000000000000000005a1",
+      "address": "0x1bd2F176a812e312077BcA87e37c08432Bb09F3e",
+      "poolType": "ComposableStable",
+      "symbol": "qETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x93ef1Ea305D11A9b2a3EbB9bB4FCc34695292E7d",
+          "weight": "null",
+          "symbol": "qETH"
+        },
+        {
+          "address": "0xbB6881874825E60e1160416D6C426eae65f2459E",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x93ef1Ea305D11A9b2a3EbB9bB4FCc34695292E7d": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x93ef1ea305d11a9b2a3ebb9bb4fcc34695292e7d.png",
+      "0xbB6881874825E60e1160416D6C426eae65f2459E": ""
+    }
+  },
+  {
+    "address": "0x5669736FD1dF3572f9D519FcCf7536A750CFAc62",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xae8535c23afedda9304b03c68a3563b75fc8f92b0000000000000000000005a0",
+      "address": "0xaE8535c23afeDdA9304B03c68a3563B75fc8f92b",
+      "poolType": "ComposableStable",
+      "symbol": "swETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0xbB6881874825E60e1160416D6C426eae65f2459E",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xf951E335afb289353dc249e82926178EaC7DEd78",
+          "weight": "null",
+          "symbol": "swETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xbB6881874825E60e1160416D6C426eae65f2459E": "",
+      "0xf951E335afb289353dc249e82926178EaC7DEd78": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf951e335afb289353dc249e82926178eac7ded78.png"
+    }
+  },
+  {
+    "address": "0xe9E6E9597123034Fa3fc73D482852e18EdF9c282",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xe8c56405bc405840154d9b572927f4197d110de10000000000000000000005a4",
+      "address": "0xE8C56405Bc405840154d9b572927F4197D110dE1",
+      "poolType": "ComposableStable",
+      "symbol": "rETH/bbaWETH BPT ",
+      "tokens": [
+        {
+          "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "weight": "null",
+          "symbol": "rETH"
+        },
+        {
+          "address": "0xbB6881874825E60e1160416D6C426eae65f2459E",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xae78736Cd615f374D3085123A210448E74Fc6393": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+      "0xbB6881874825E60e1160416D6C426eae65f2459E": ""
+    }
+  },
+  {
+    "address": "0x9aaAf6757BE9e115895429EF6B81e05dCB951646",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x158e0fbc2271e1dcebadd365a22e2b4dd173c0db0002000000000000000005a5",
+      "address": "0x158e0fBC2271E1dCEbadD365a22E2B4dD173C0DB",
+      "poolType": "Weighted",
+      "symbol": "80IDLE-20USDC",
+      "tokens": [
+        {
+          "address": "0x875773784Af8135eA0ef43b5a374AaD105c5D39e",
+          "weight": "0.8",
+          "symbol": "IDLE"
+        },
+        {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "weight": "0.2",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x875773784Af8135eA0ef43b5a374AaD105c5D39e": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x875773784af8135ea0ef43b5a374aad105c5d39e.png",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  },
+  {
+    "address": "0x639F4583E505e9E0A16C5D90E1AF61b47415A3A9",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xe2d16b0a39f3fbb4389a0e8f1efcbecfb3d1e6e10000000000000000000005a7",
+      "address": "0xE2D16b0A39F3FBb4389a0E8F1efCBecFB3d1E6E1",
+      "poolType": "ComposableStable",
+      "symbol": "DUSD/bbaUSD-BPT",
+      "tokens": [
+        {
+          "address": "0xa48F322F8b3edff967629Af79E027628b9Dd1298",
+          "weight": "null",
+          "symbol": "DUSD"
+        },
+        {
+          "address": "0xc443C15033FCB6Cf72cC24f1BDA0Db070DdD9786",
+          "weight": "null",
+          "symbol": "bb-a-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xa48F322F8b3edff967629Af79E027628b9Dd1298": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa48f322f8b3edff967629af79e027628b9dd1298.png",
+      "0xc443C15033FCB6Cf72cC24f1BDA0Db070DdD9786": "https://assets.coingecko.com/coins/images/25769/large/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2.png?1653604699"
+    }
+  },
+  {
+    "address": "0x44bc38d3aF025C0EA9a4729E79d6E44244d68Ac6",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x759fabc513accd292ada967c4dd7bb94da39232e0002000000000000000005a8",
+      "address": "0x759FABc513AccD292ADA967C4DD7Bb94Da39232e",
+      "poolType": "Weighted",
+      "symbol": "80RATE/20WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x695BD8b642342d792a34392bEa1461b98895300B",
+          "weight": "0.8",
+          "symbol": "RATE"
+        },
+        {
+          "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x695BD8b642342d792a34392bEa1461b98895300B": "",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png"
+    }
+  },
+  {
+    "address": "0x5E23599eBE87A5A140f295C2fC6aAedb10955497",
+    "network": 1,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1690830527,
+    "pool": {
+      "id": "0x616d4d131f1147ac3b3c3cc752bab8613395b2bb000200000000000000000584",
+      "address": "0x616D4D131F1147aC3B3C3CC752BAB8613395B2bB",
+      "poolType": "Stable",
+      "symbol": "B-yBAL-STABLE",
+      "tokens": [
+        {
+          "address": "0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56",
+          "weight": "null",
+          "symbol": "B-80BAL-20WETH"
+        },
+        {
+          "address": "0x98E86Ed5b0E48734430BfBe92101156C75418cad",
+          "weight": "null",
+          "symbol": "yBAL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png",
+      "0x98E86Ed5b0E48734430BfBe92101156C75418cad": ""
+    }
+  },
+  {
+    "address": "0xf0f572ad66baacDd07d8c7ea3e0E5EFA56a76081",
+    "network": 5,
+    "isKilled": false,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1654312702,
+    "pool": {
+      "id": "0x16faf9f73748013155b7bc116a3008b57332d1e600020000000000000000005b",
+      "address": "0x16faF9f73748013155B7bC116a3008b57332D1e6",
+      "poolType": "Weighted",
+      "symbol": "B-50WBTC-50WETH",
+      "tokens": [
+        {
+          "address": "0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9",
+          "weight": "0.5",
+          "symbol": "WBTC"
+        },
+        {
+          "address": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9": "",
+      "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1": ""
+    }
+  },
+  {
+    "address": "0xDaCD99029b4B94CD04fE364aAc370829621C1C64",
+    "network": 10,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x4fd63966879300cafafbb35d157dc5229278ed2300020000000000000000002b",
+      "address": "0x4Fd63966879300caFafBB35D157dC5229278Ed23",
+      "poolType": "MetaStable",
+      "symbol": "BPT-rETH-ETH",
+      "tokens": [
+        {
+          "address": "0x4200000000000000000000000000000000000006",
+          "weight": "null",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0x9Bcef72be871e61ED4fBbc7630889beE758eb81D",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4200000000000000000000000000000000000006": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4200000000000000000000000000000000000006.png",
+      "0x9Bcef72be871e61ED4fBbc7630889beE758eb81D": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/optimism/assets/0x9Bcef72be871e61ED4fBbc7630889beE758eb81D/logo.png"
+    }
+  },
+  {
+    "address": "0x1Ce5bf7e6C16C567DeFd625e0911Bfd0FC7f2d7d",
+    "network": 10,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1688412059,
+    "pool": {
+      "id": "0x39965c9dab5448482cf7e002f583c812ceb53046000100000000000000000003",
+      "address": "0x39965c9dAb5448482Cf7e002F583c812Ceb53046",
+      "poolType": "Weighted",
+      "symbol": "BPT-ROAD",
+      "tokens": [
+        {
+          "address": "0x4200000000000000000000000000000000000006",
+          "weight": "0.4",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0x4200000000000000000000000000000000000042",
+          "weight": "0.4",
+          "symbol": "OP"
+        },
+        {
+          "address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+          "weight": "0.2",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4200000000000000000000000000000000000006": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4200000000000000000000000000000000000006.png",
+      "0x4200000000000000000000000000000000000042": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/optimism/assets/0x4200000000000000000000000000000000000042/logo.png",
+      "0x7F5c764cBc14f9669B88837ca1490cCa17c31607": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/optimism/assets/0x7F5c764cBc14f9669B88837ca1490cCa17c31607/logo.png"
+    }
+  },
+  {
+    "address": "0xd0b6787589d33B4F7aA5a27f36497e091e78a2ad",
+    "network": 10,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1688412059,
+    "pool": {
+      "id": "0x1d95129c18a8c91c464111fdf7d0eb241b37a9850002000000000000000000c1",
+      "address": "0x1D95129c18a8c91C464111FDf7d0Eb241B37a985",
+      "poolType": "Weighted",
+      "symbol": "BPT-RESERVE",
+      "tokens": [
+        {
+          "address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+          "weight": "0.5",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0xc5b001DC33727F8F26880B184090D3E252470D45",
+          "weight": "0.5",
+          "symbol": "ERN"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7F5c764cBc14f9669B88837ca1490cCa17c31607": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/optimism/assets/0x7F5c764cBc14f9669B88837ca1490cCa17c31607/logo.png",
+      "0xc5b001DC33727F8F26880B184090D3E252470D45": ""
+    }
+  },
+  {
+    "address": "0x0BFcF593C149Ddbeedb190667d24D30D2E38AF73",
+    "network": 10,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1688412059,
+    "pool": {
+      "id": "0xd20f6f1d8a675cdca155cb07b5dc9042c467153f0002000000000000000000bc",
+      "address": "0xd20f6F1D8a675cDCa155Cb07b5dC9042c467153f",
+      "poolType": "Weighted",
+      "symbol": "BPT-BOATH",
+      "tokens": [
+        {
+          "address": "0x39FdE572a18448F8139b7788099F0a0740f51205",
+          "weight": "0.8",
+          "symbol": "OATH"
+        },
+        {
+          "address": "0x4200000000000000000000000000000000000006",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x39FdE572a18448F8139b7788099F0a0740f51205": "",
+      "0x4200000000000000000000000000000000000006": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4200000000000000000000000000000000000006.png"
+    }
+  },
+  {
+    "address": "0xdc08146530DD9910F8ab4D0aD2C184f87e903540",
+    "network": 10,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1688412059,
+    "pool": {
+      "id": "0x098f32d98d0d64dba199fc1923d3bf4192e787190001000000000000000000d2",
+      "address": "0x098f32D98d0D64Dba199FC1923D3BF4192E78719",
+      "poolType": "Weighted",
+      "symbol": "bb-rf-SOTRI",
+      "tokens": [
+        {
+          "address": "0x6af3737F6d58Ae8Bcb9f2B597125D37244596E59",
+          "weight": "0.25",
+          "symbol": "bb-rf-soWBTC"
+        },
+        {
+          "address": "0x7e9250cC13559eB50536859e8C076Ef53e275Fb3",
+          "weight": "0.5",
+          "symbol": "bb-rf-soWSTETH"
+        },
+        {
+          "address": "0xEdcfaF390906a8f91fb35B7bAC23f3111dBaEe1C",
+          "weight": "0.25",
+          "symbol": "bb-rf-soUSDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6af3737F6d58Ae8Bcb9f2B597125D37244596E59": "",
+      "0x7e9250cC13559eB50536859e8C076Ef53e275Fb3": "",
+      "0xEdcfaF390906a8f91fb35B7bAC23f3111dBaEe1C": ""
+    }
+  },
+  {
+    "address": "0x1b8C2C972c67f4A5B43C2EbE07E64fCB88ACee87",
+    "network": 10,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1688412059,
+    "pool": {
+      "id": "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb200020000000000000000008b",
+      "address": "0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2",
+      "poolType": "MetaStable",
+      "symbol": "BPT-WSTETH-WETH",
+      "tokens": [
+        {
+          "address": "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0x4200000000000000000000000000000000000006",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x1f32b1c2345538c0c6f582fcb022739c4a194ebb.png",
+      "0x4200000000000000000000000000000000000006": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4200000000000000000000000000000000000006.png"
+    }
+  },
+  {
+    "address": "0xE9816654a37aaBAEC2A742f1a1cE4c99D42c08D2",
+    "network": 10,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690830527,
+    "pool": {
+      "id": "0xcd7b2232b7435595bbc7fd7962f1f352fc2cc61a0000000000000000000000f0",
+      "address": "0xCd7B2232B7435595bBc7FD7962f1f352fc2cC61a",
+      "poolType": "ComposableStable",
+      "symbol": "bb-rf-usd",
+      "tokens": [
+        {
+          "address": "0x20715545C15C76461861Cb0D6ba96929766D05A5",
+          "weight": "null",
+          "symbol": "bb-rfUSDT"
+        },
+        {
+          "address": "0xA5D4802B4ce6b745B0C9e1b4a79c093D197869c8",
+          "weight": "null",
+          "symbol": "bb-rfDAI"
+        },
+        {
+          "address": "0xF970659221BB9d01B615321b63a26E857ffC030B",
+          "weight": "null",
+          "symbol": "bb-rfUSDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x20715545C15C76461861Cb0D6ba96929766D05A5": "",
+      "0xA5D4802B4ce6b745B0C9e1b4a79c093D197869c8": "",
+      "0xF970659221BB9d01B615321b63a26E857ffC030B": ""
+    }
+  },
+  {
+    "address": "0xAb6b60F389218AFf06DE279BF8c69A246568b5a6",
+    "network": 10,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690830527,
+    "pool": {
+      "id": "0x8a2872fd28f42bd9f6559907235e83fbf4167f480001000000000000000000f2",
+      "address": "0x8a2872fd28F42BD9F6559907235E83FbF4167f48",
+      "poolType": "Weighted",
+      "symbol": "bb-rf-triple",
+      "tokens": [
+        {
+          "address": "0x48aCE81C09382bfC08eD102e7eadd37e3B049752",
+          "weight": "0.5",
+          "symbol": "bb-rfWSTETH"
+        },
+        {
+          "address": "0x8025586aC5fB265A23B9492E7414BecCc2059ec3",
+          "weight": "0.25",
+          "symbol": "bb-rfWBTC"
+        },
+        {
+          "address": "0xF970659221BB9d01B615321b63a26E857ffC030B",
+          "weight": "0.25",
+          "symbol": "bb-rfUSDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x48aCE81C09382bfC08eD102e7eadd37e3B049752": "",
+      "0x8025586aC5fB265A23B9492E7414BecCc2059ec3": "",
+      "0xF970659221BB9d01B615321b63a26E857ffC030B": ""
+    }
+  },
+  {
+    "address": "0x21b2Ef3DC22B7bd4634205081c667e39742075E2",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0x66f33ae36dd80327744207a48122f874634b3ada000100000000000000000013",
+      "address": "0x66F33Ae36dD80327744207a48122F874634B3adA",
+      "poolType": "Weighted",
+      "symbol": "agUSD-agWETH-agWBTC",
+      "tokens": [
+        {
+          "address": "0xbb9Cd48d33033F5EfFBeDec9Dd700C7D7E1dCF50",
+          "weight": "0.333333333",
+          "symbol": "bb-ag-WETH"
+        },
+        {
+          "address": "0xd4015683b8153666190e0B2bEC352580EBC4CaCa",
+          "weight": "0.333333334",
+          "symbol": "bb-ag-WBTC"
+        },
+        {
+          "address": "0xFEdb19Ec000d38d92Af4B21436870F115db22725",
+          "weight": "0.333333333",
+          "symbol": "bb-ag-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xbb9Cd48d33033F5EfFBeDec9Dd700C7D7E1dCF50": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbb9cd48d33033f5effbedec9dd700c7d7e1dcf50.png",
+      "0xd4015683b8153666190e0B2bEC352580EBC4CaCa": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd4015683b8153666190e0b2bec352580ebc4caca.png",
+      "0xFEdb19Ec000d38d92Af4B21436870F115db22725": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfedb19ec000d38d92af4b21436870f115db22725.png"
+    }
+  },
+  {
+    "address": "0x56A65cC666bfe538c5a031942369F6F63eb42240",
+    "network": 100,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1677684467,
+    "pool": {
+      "id": "0x66f33ae36dd80327744207a48122f874634b3ada000100000000000000000013",
+      "address": "0x66F33Ae36dD80327744207a48122F874634B3adA",
+      "poolType": "Weighted",
+      "symbol": "agUSD-agWETH-agWBTC",
+      "tokens": [
+        {
+          "address": "0xbb9Cd48d33033F5EfFBeDec9Dd700C7D7E1dCF50",
+          "weight": "0.333333333",
+          "symbol": "bb-ag-WETH"
+        },
+        {
+          "address": "0xd4015683b8153666190e0B2bEC352580EBC4CaCa",
+          "weight": "0.333333334",
+          "symbol": "bb-ag-WBTC"
+        },
+        {
+          "address": "0xFEdb19Ec000d38d92Af4B21436870F115db22725",
+          "weight": "0.333333333",
+          "symbol": "bb-ag-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xbb9Cd48d33033F5EfFBeDec9Dd700C7D7E1dCF50": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbb9cd48d33033f5effbedec9dd700c7d7e1dcf50.png",
+      "0xd4015683b8153666190e0B2bEC352580EBC4CaCa": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd4015683b8153666190e0b2bec352580ebc4caca.png",
+      "0xFEdb19Ec000d38d92Af4B21436870F115db22725": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfedb19ec000d38d92af4b21436870f115db22725.png"
+    }
+  },
+  {
+    "address": "0xE41736b4e78be41Bd03EbAf8F86EA493C6e9EA96",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0xf48f01dcb2cbb3ee1f6aab0e742c2d3941039d56000200000000000000000012",
+      "address": "0xF48f01DCB2CbB3ee1f6AaB0e742c2D3941039d56",
+      "poolType": "Weighted",
+      "symbol": "50bbagGNO-50bbagWETH",
+      "tokens": [
+        {
+          "address": "0xbb9Cd48d33033F5EfFBeDec9Dd700C7D7E1dCF50",
+          "weight": "0.5",
+          "symbol": "bb-ag-WETH"
+        },
+        {
+          "address": "0xFFFf76A3280e95dC855696111C2562Da09db2Ac0",
+          "weight": "0.5",
+          "symbol": "bb-ag-GNO"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xbb9Cd48d33033F5EfFBeDec9Dd700C7D7E1dCF50": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbb9cd48d33033f5effbedec9dd700c7d7e1dcf50.png",
+      "0xFFFf76A3280e95dC855696111C2562Da09db2Ac0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xffff76a3280e95dc855696111c2562da09db2ac0.png"
+    }
+  },
+  {
+    "address": "0xcB2c2AF6c3E88b4a89aa2aae1D7C8120EEe9Ad0e",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0xb973ca96a3f0d61045f53255e319aedb6ed49240000200000000000000000011",
+      "address": "0xB973Ca96a3f0D61045f53255E319AEDb6ED49240",
+      "poolType": "Weighted",
+      "symbol": "50bbagGNO-50bbagUSD",
+      "tokens": [
+        {
+          "address": "0xFEdb19Ec000d38d92Af4B21436870F115db22725",
+          "weight": "0.5",
+          "symbol": "bb-ag-USD"
+        },
+        {
+          "address": "0xFFFf76A3280e95dC855696111C2562Da09db2Ac0",
+          "weight": "0.5",
+          "symbol": "bb-ag-GNO"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xFEdb19Ec000d38d92Af4B21436870F115db22725": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfedb19ec000d38d92af4b21436870f115db22725.png",
+      "0xFFFf76A3280e95dC855696111C2562Da09db2Ac0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xffff76a3280e95dc855696111c2562da09db2ac0.png"
+    }
+  },
+  {
+    "address": "0x3B6A85B5e1e6205ebF4d4eabf147D10e8e4bf0A5",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0xfedb19ec000d38d92af4b21436870f115db22725000000000000000000000010",
+      "address": "0xFEdb19Ec000d38d92Af4B21436870F115db22725",
+      "poolType": "ComposableStable",
+      "symbol": "bb-ag-USD",
+      "tokens": [
+        {
+          "address": "0x41211BBa6d37F5a74b22e667533F080C7C7f3F13",
+          "weight": "null",
+          "symbol": "bb-ag-WXDAI"
+        },
+        {
+          "address": "0xd16f72b02dA5f51231fDe542A8B9E2777a478c88",
+          "weight": "null",
+          "symbol": "bb-ag-USDT"
+        },
+        {
+          "address": "0xE7f88d7d4EF2eb18FCF9Dd7216BA7Da1c46f3dD6",
+          "weight": "null",
+          "symbol": "bb-ag-USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x41211BBa6d37F5a74b22e667533F080C7C7f3F13": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x41211bba6d37f5a74b22e667533f080c7c7f3f13.png",
+      "0xd16f72b02dA5f51231fDe542A8B9E2777a478c88": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd16f72b02da5f51231fde542a8b9e2777a478c88.png",
+      "0xE7f88d7d4EF2eb18FCF9Dd7216BA7Da1c46f3dD6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe7f88d7d4ef2eb18fcf9dd7216ba7da1c46f3dd6.png"
+    }
+  },
+  {
+    "address": "0xf8C85bd74FeE26831336B51A90587145391a27Ba",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1686141695,
+    "pool": {
+      "id": "0xbad20c15a773bf03ab973302f61fabcea5101f0a000000000000000000000034",
+      "address": "0xbAd20c15A773bf03ab973302F61FAbceA5101f0A",
+      "poolType": "ComposableStable",
+      "symbol": "bb-WETH-wstETH",
+      "tokens": [
+        {
+          "address": "0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1",
+          "weight": "null",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6",
+          "weight": "null",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1628852295",
+      "0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443"
+    }
+  },
+  {
+    "address": "0x7F75ecd3cFd8cE8bf45f9639A226121ca8bBe4ff",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1686141695,
+    "pool": {
+      "id": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95000000000000000000000030",
+      "address": "0x5C78d05b8ECF97507d1cf70646082c54FaA4dA95",
+      "poolType": "ComposableStable",
+      "symbol": "bb-agEUR-EURe",
+      "tokens": [
+        {
+          "address": "0x4b1E2c2762667331Bc91648052F646d1b0d35984",
+          "weight": "null",
+          "symbol": "agEUR"
+        },
+        {
+          "address": "0xcB444e90D8198415266c6a2724b7900fb12FC56E",
+          "weight": "null",
+          "symbol": "EURe"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4b1E2c2762667331Bc91648052F646d1b0d35984": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4b1e2c2762667331bc91648052f646d1b0d35984.png",
+      "0xcB444e90D8198415266c6a2724b7900fb12FC56E": "https://assets.coingecko.com/coins/images/23354/large/eur.png?1643926562"
+    }
+  },
+  {
+    "address": "0xc61e7E858b5a60122607f5C7DF223a53b01a1389",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1686141695,
+    "pool": {
+      "id": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd9900020000000000000000001e",
+      "address": "0x21d4c792Ea7E38e0D0819c2011A2b1Cb7252Bd99",
+      "poolType": "Weighted",
+      "symbol": "50COW-50GNO",
+      "tokens": [
+        {
+          "address": "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
+          "weight": "0.5",
+          "symbol": "COW"
+        },
+        {
+          "address": "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb",
+          "weight": "0.5",
+          "symbol": "GNO"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x177127622c4A00F3d409B75571e12cB3c8973d3c": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x177127622c4a00f3d409b75571e12cb3c8973d3c.png",
+      "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9c58bacc331c9aa871afd802db6379a98e80cedb.png"
+    }
+  },
+  {
+    "address": "0x3A7Ed8916Ebb9131966b9b3af3cd8B9adcc53559",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xba1a5b19d09a79dada039b1f974015c5a989d5fd000100000000000000000046",
+      "address": "0xba1a5B19D09A79DADA039B1f974015c5A989d5FD",
+      "poolType": "Weighted",
+      "symbol": "agUSD-agWETH-agWBTC",
+      "tokens": [
+        {
+          "address": "0xbb9Cd48d33033F5EfFBeDec9Dd700C7D7E1dCF50",
+          "weight": "0.333333333",
+          "symbol": "bb-ag-WETH"
+        },
+        {
+          "address": "0xd4015683b8153666190e0B2bEC352580EBC4CaCa",
+          "weight": "0.333333334",
+          "symbol": "bb-ag-WBTC"
+        },
+        {
+          "address": "0xe15CaC1DF3621e001f76210Ab12A7f1A1691481f",
+          "weight": "0.333333333",
+          "symbol": "bb-ag-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xbb9Cd48d33033F5EfFBeDec9Dd700C7D7E1dCF50": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbb9cd48d33033f5effbedec9dd700c7d7e1dcf50.png",
+      "0xd4015683b8153666190e0B2bEC352580EBC4CaCa": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd4015683b8153666190e0b2bec352580ebc4caca.png",
+      "0xe15CaC1DF3621e001f76210Ab12A7f1A1691481f": ""
+    }
+  },
+  {
+    "address": "0x7a4e71a8A33d3b385279079c503ca93905dd553e",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x4de21b365d6543661d0e105e579a34b963862497000200000000000000000045",
+      "address": "0x4De21b365D6543661D0e105E579A34B963862497",
+      "poolType": "Weighted",
+      "symbol": "50bbagGNO-50bbagUSD",
+      "tokens": [
+        {
+          "address": "0xe15CaC1DF3621e001f76210Ab12A7f1A1691481f",
+          "weight": "0.5",
+          "symbol": "bb-ag-USD"
+        },
+        {
+          "address": "0xFFFf76A3280e95dC855696111C2562Da09db2Ac0",
+          "weight": "0.5",
+          "symbol": "bb-ag-GNO"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xe15CaC1DF3621e001f76210Ab12A7f1A1691481f": "",
+      "0xFFFf76A3280e95dC855696111C2562Da09db2Ac0": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xffff76a3280e95dc855696111c2562da09db2ac0.png"
+    }
+  },
+  {
+    "address": "0x774D0F67DcFA5568cA435c70fbA272C64352d859",
+    "network": 100,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xe15cac1df3621e001f76210ab12a7f1a1691481f000000000000000000000044",
+      "address": "0xe15CaC1DF3621e001f76210Ab12A7f1A1691481f",
+      "poolType": "ComposableStable",
+      "symbol": "bb-ag-USD",
+      "tokens": [
+        {
+          "address": "0x41211BBa6d37F5a74b22e667533F080C7C7f3F13",
+          "weight": "null",
+          "symbol": "bb-ag-WXDAI"
+        },
+        {
+          "address": "0xd16f72b02dA5f51231fDe542A8B9E2777a478c88",
+          "weight": "null",
+          "symbol": "bb-ag-USDT"
+        },
+        {
+          "address": "0xE7f88d7d4EF2eb18FCF9Dd7216BA7Da1c46f3dD6",
+          "weight": "null",
+          "symbol": "bb-ag-USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x41211BBa6d37F5a74b22e667533F080C7C7f3F13": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x41211bba6d37f5a74b22e667533f080c7c7f3f13.png",
+      "0xd16f72b02dA5f51231fDe542A8B9E2777a478c88": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd16f72b02da5f51231fde542a8b9e2777a478c88.png",
+      "0xE7f88d7d4EF2eb18FCF9Dd7216BA7Da1c46f3dD6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe7f88d7d4ef2eb18fcf9dd7216ba7da1c46f3dd6.png"
+    }
+  },
+  {
+    "address": "0x1604b7E80975555e0aCEaca9C81807FbB4D65Cf1",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x03cd191f589d12b0582a99808cf19851e468e6b500010000000000000000000a",
+      "address": "0x03cD191F589d12b0582a99808cf19851E468E6B5",
+      "poolType": "Weighted",
+      "symbol": "BPTC",
+      "tokens": [
+        {
+          "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+          "weight": "0.333333333333333333",
+          "symbol": "WBTC"
+        },
+        {
+          "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+          "weight": "0.333333333333333333",
+          "symbol": "USDC"
+        },
+        {
+          "address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+          "weight": "0.333333333333333334",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1548822744",
+      "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+      "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619/logo.png"
+    }
+  },
+  {
+    "address": "0xc3bB46B8196C3F188c6A373a6C4Fde792CA78653",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1650405699,
+    "pool": {
+      "id": "0xaf5e0b5425de1f5a630a8cb5aa9d97b8141c908d000200000000000000000366",
+      "address": "0xaF5E0B5425dE1F5a630A8cB5AA9D97B8141C908D",
+      "poolType": "MetaStable",
+      "symbol": "B-stMATIC-STABLE",
+      "tokens": [
+        {
+          "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+          "weight": "null",
+          "symbol": "WMATIC"
+        },
+        {
+          "address": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+          "weight": "null",
+          "symbol": "stMATIC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+      "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png"
+    }
+  },
+  {
+    "address": "0xcF5938cA6d9F19C73010c7493e19c02AcFA8d24D",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1657479716,
+    "pool": {
+      "id": "0xb797adfb7b268faeaa90cadbfed464c76ee599cd0002000000000000000005ba",
+      "address": "0xB797AdfB7b268faeaA90CAdBfEd464C76ee599Cd",
+      "poolType": "Stable",
+      "symbol": "tetuBAL-BALWETH",
+      "tokens": [
+        {
+          "address": "0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f",
+          "weight": "null",
+          "symbol": "20WETH-80BAL"
+        },
+        {
+          "address": "0x7fC9E0Aa043787BFad28e29632AdA302C790Ce33",
+          "weight": "null",
+          "symbol": "tetuBAL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f.png",
+      "0x7fC9E0Aa043787BFad28e29632AdA302C790Ce33": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7fc9e0aa043787bfad28e29632ada302c790ce33.png"
+    }
+  },
+  {
+    "address": "0xd1177e2157a7fD6A0484B79f8E50e8A9305F8063",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xb797adfb7b268faeaa90cadbfed464c76ee599cd0002000000000000000005ba",
+      "address": "0xB797AdfB7b268faeaA90CAdBfEd464C76ee599Cd",
+      "poolType": "Stable",
+      "symbol": "tetuBAL-BALWETH",
+      "tokens": [
+        {
+          "address": "0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f",
+          "weight": "null",
+          "symbol": "20WETH-80BAL"
+        },
+        {
+          "address": "0x7fC9E0Aa043787BFad28e29632AdA302C790Ce33",
+          "weight": "null",
+          "symbol": "tetuBAL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f.png",
+      "0x7fC9E0Aa043787BFad28e29632AdA302C790Ce33": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7fc9e0aa043787bfad28e29632ada302c790ce33.png"
+    }
+  },
+  {
+    "address": "0xf7C3B4e1EdcB00f0230BFe03D937e26A5e654fD4",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1663017781,
+    "pool": {
+      "id": "0x8159462d255c1d24915cb51ec361f700174cd99400000000000000000000075d",
+      "address": "0x8159462d255C1D24915CB51ec361F700174cD994",
+      "poolType": "ComposableStable",
+      "symbol": "B-stMATIC-Stable",
+      "tokens": [
+        {
+          "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+          "weight": "null",
+          "symbol": "WMATIC"
+        },
+        {
+          "address": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+          "weight": "null",
+          "symbol": "stMATIC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+      "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png"
+    }
+  },
+  {
+    "address": "0x2C967D6611C60274db45E0BB34c64fb5F504eDE7",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1663017781,
+    "pool": {
+      "id": "0xb20fc01d21a50d2c734c4a1262b4404d41fa7bf000000000000000000000075c",
+      "address": "0xb20fC01D21A50d2C734C4a1262B4404d41fA7BF0",
+      "poolType": "ComposableStable",
+      "symbol": " B-MaticX-Stable",
+      "tokens": [
+        {
+          "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+          "weight": "null",
+          "symbol": "WMATIC"
+        },
+        {
+          "address": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
+          "weight": "null",
+          "symbol": "MaticX"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+      "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png"
+    }
+  },
+  {
+    "address": "0x1f5Cb5b832f27E24A3b0ad4b837d3Ed26FF7aC6E",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xe2f706ef1f7240b803aae877c9c762644bb808d80002000000000000000008c2",
+      "address": "0xE2f706EF1f7240b803AAe877C9C762644bb808d8",
+      "poolType": "Weighted",
+      "symbol": "80TETU-20USDC",
+      "tokens": [
+        {
+          "address": "0x255707B70BF90aa112006E1b07B9AeA6De021424",
+          "weight": "0.8",
+          "symbol": "TETU"
+        },
+        {
+          "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+          "weight": "0.2",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x255707B70BF90aa112006E1b07B9AeA6De021424": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x255707b70bf90aa112006e1b07b9aea6de021424.png",
+      "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png"
+    }
+  },
+  {
+    "address": "0xE77239359CE4D445Fed27C17Da23B8024d35e456",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1672444283,
+    "pool": {
+      "id": "0x4a0b73f0d13ff6d43e304a174697e3d5cfd310a400020000000000000000091c",
+      "address": "0x4A0b73f0D13fF6d43e304a174697e3d5CFd310a4",
+      "poolType": "Weighted",
+      "symbol": "2BRLUSD-boosted",
+      "tokens": [
+        {
+          "address": "0x48e6B98ef6329f8f0A30eBB8c7C960330d648085",
+          "weight": "0.5",
+          "symbol": "bb-am-usd"
+        },
+        {
+          "address": "0xE22483774bd8611bE2Ad2F4194078DaC9159F4bA",
+          "weight": "0.5",
+          "symbol": "2BRL (BRZ)"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x48e6B98ef6329f8f0A30eBB8c7C960330d648085": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x48e6b98ef6329f8f0a30ebb8c7c960330d648085.png",
+      "0xE22483774bd8611bE2Ad2F4194078DaC9159F4bA": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe22483774bd8611be2ad2f4194078dac9159f4ba.png"
+    }
+  },
+  {
+    "address": "0xF0d887c1f5996C91402EB69Ab525f028DD5d7578",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1672444283,
+    "pool": {
+      "id": "0xe22483774bd8611be2ad2f4194078dac9159f4ba0000000000000000000008f0",
+      "address": "0xE22483774bd8611bE2Ad2F4194078DaC9159F4bA",
+      "poolType": "ComposableStable",
+      "symbol": "2BRL (BRZ)",
+      "tokens": [
+        {
+          "address": "0x491a4eB4f1FC3BfF8E1d2FC856a6A46663aD556f",
+          "weight": "null",
+          "symbol": "BRZ"
+        },
+        {
+          "address": "0xf2f77FE7b8e66571E0fca7104c4d670BF1C8d722",
+          "weight": "null",
+          "symbol": "jBRL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x491a4eB4f1FC3BfF8E1d2FC856a6A46663aD556f": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x491a4eb4f1fc3bff8e1d2fc856a6a46663ad556f.png",
+      "0xf2f77FE7b8e66571E0fca7104c4d670BF1C8d722": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf2f77fe7b8e66571e0fca7104c4d670bf1c8d722.png"
+    }
+  },
+  {
+    "address": "0x90437a1D2F6C0935Dd6056f07f05C068f2A507F9",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1676389091,
+    "pool": {
+      "id": "0xf3312968c7d768c19107731100ece7d4780b47b2000200000000000000000a50",
+      "address": "0xf3312968c7D768C19107731100Ece7d4780b47B2",
+      "poolType": "Weighted",
+      "symbol": "20WMATIC-80SPHERE",
+      "tokens": [
+        {
+          "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+          "weight": "0.2",
+          "symbol": "WMATIC"
+        },
+        {
+          "address": "0x62F594339830b90AE4C084aE7D223fFAFd9658A7",
+          "weight": "0.8",
+          "symbol": "SPHERE"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+      "0x62F594339830b90AE4C084aE7D223fFAFd9658A7": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x62f594339830b90ae4c084ae7d223ffafd9658a7.png"
+    }
+  },
+  {
+    "address": "0xA4c104AB9116a84714C081e0Ed6d750221e4c756",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xf3312968c7d768c19107731100ece7d4780b47b2000200000000000000000a50",
+      "address": "0xf3312968c7D768C19107731100Ece7d4780b47B2",
+      "poolType": "Weighted",
+      "symbol": "20WMATIC-80SPHERE",
+      "tokens": [
+        {
+          "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+          "weight": "0.2",
+          "symbol": "WMATIC"
+        },
+        {
+          "address": "0x62F594339830b90AE4C084aE7D223fFAFd9658A7",
+          "weight": "0.8",
+          "symbol": "SPHERE"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+      "0x62F594339830b90AE4C084aE7D223fFAFd9658A7": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x62f594339830b90ae4c084ae7d223ffafd9658a7.png"
+    }
+  },
+  {
+    "address": "0xe603cc3f7Ec38cC6ab1Eef7FdA9Bb599493e9a24",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xeab6455f8a99390b941a33bbdaf615abdf93455e000200000000000000000a66",
+      "address": "0xeaB6455f8A99390B941A33BBDAf615abdf93455e",
+      "poolType": "Weighted",
+      "symbol": "50THX-50stMATIC",
+      "tokens": [
+        {
+          "address": "0x2934b36ca9A4B31E633C5BE670C8C8b28b6aA015",
+          "weight": "0.5",
+          "symbol": "THX"
+        },
+        {
+          "address": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+          "weight": "0.5",
+          "symbol": "stMATIC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2934b36ca9A4B31E633C5BE670C8C8b28b6aA015": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x2934b36ca9a4b31e633c5be670c8c8b28b6aa015.png",
+      "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png"
+    }
+  },
+  {
+    "address": "0x0a650F4E0C416c24C8713c322d5AAA531a5A0112",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x577f6076e558818a5df21ce4acde9a9623ec0b4c000200000000000000000a64",
+      "address": "0x577f6076E558818A5dF21Ce4acdE9A9623eC0b4c",
+      "poolType": "Weighted",
+      "symbol": "80SD-20maticX",
+      "tokens": [
+        {
+          "address": "0x1d734A02eF1e1f5886e66b0673b71Af5B53ffA94",
+          "weight": "0.8",
+          "symbol": "SD"
+        },
+        {
+          "address": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
+          "weight": "0.2",
+          "symbol": "MaticX"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x1d734A02eF1e1f5886e66b0673b71Af5B53ffA94": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x1d734a02ef1e1f5886e66b0673b71af5b53ffa94.png",
+      "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png"
+    }
+  },
+  {
+    "address": "0x790DE8ABE859f399023BCe73B5FE5C4870cD816A",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x77e97d4908be63394bc5dff72c8c7bddf1699882000000000000000000000a6a",
+      "address": "0x77e97D4908Be63394bc5DFf72C8C7Bddf1699882",
+      "poolType": "ComposableStable",
+      "symbol": "2eur (agEUR)",
+      "tokens": [
+        {
+          "address": "0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c",
+          "weight": "null",
+          "symbol": "jEUR"
+        },
+        {
+          "address": "0xE0B52e49357Fd4DAf2c15e02058DCE6BC0057db4",
+          "weight": "null",
+          "symbol": "agEUR"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4e3decbb3645551b8a19f0ea1678079fcb33fb4c.png",
+      "0xE0B52e49357Fd4DAf2c15e02058DCE6BC0057db4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe0b52e49357fd4daf2c15e02058dce6bc0057db4.png"
+    }
+  },
+  {
+    "address": "0x16289F675Ca54312a8fCF99341e7439982888077",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x513cdee00251f39de280d9e5f771a6eafebcc88e000000000000000000000a6b",
+      "address": "0x513CdEE00251F39DE280d9E5f771A6eaFebCc88E",
+      "poolType": "ComposableStable",
+      "symbol": "2eur (PAR)",
+      "tokens": [
+        {
+          "address": "0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c",
+          "weight": "null",
+          "symbol": "jEUR"
+        },
+        {
+          "address": "0xE2Aa7db6dA1dAE97C5f5C6914d285fBfCC32A128",
+          "weight": "null",
+          "symbol": "PAR"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4e3decbb3645551b8a19f0ea1678079fcb33fb4c.png",
+      "0xE2Aa7db6dA1dAE97C5f5C6914d285fBfCC32A128": "https://assets.coingecko.com/coins/images/14153/large/par_round_200.png?1614670422"
+    }
+  },
+  {
+    "address": "0x31F99c542CbE456FcbBe99D4bf849Af4D7fB5405",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xd80ef9fabfdc3b52e17f74c383cf88ee2efbf0b6000000000000000000000a65",
+      "address": "0xD80Ef9FabfdC3B52e17f74c383Cf88ee2efBf0b6",
+      "poolType": "ComposableStable",
+      "symbol": "B-tetuQi-Stable",
+      "tokens": [
+        {
+          "address": "0x4Cd44ced63d9a6FEF595f6AD3F7CED13fCEAc768",
+          "weight": "null",
+          "symbol": "tetuQi"
+        },
+        {
+          "address": "0x580A84C73811E1839F75d86d75d88cCa0c241fF4",
+          "weight": "null",
+          "symbol": "QI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4Cd44ced63d9a6FEF595f6AD3F7CED13fCEAc768": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4cd44ced63d9a6fef595f6ad3f7ced13fceac768.png",
+      "0x580A84C73811E1839F75d86d75d88cCa0c241fF4": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x580A84C73811E1839F75d86d75d88cCa0c241fF4/logo.png"
+    }
+  },
+  {
+    "address": "0x39cEEbb561a65216A4B776ea752d3137e9d6C0F0",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xb3d658d5b95bf04e2932370dd1ff976fe18dd66a000000000000000000000ace",
+      "address": "0xb3d658d5b95BF04E2932370DD1FF976fe18dd66A",
+      "poolType": "ComposableStable",
+      "symbol": "bb-t-USD",
+      "tokens": [
+        {
+          "address": "0x7c82A23B4C48D796dee36A9cA215b641C6a8709d",
+          "weight": "null",
+          "symbol": "bb-t-USDT"
+        },
+        {
+          "address": "0xae646817e458C0bE890b81e8d880206710E3c44e",
+          "weight": "null",
+          "symbol": "bb-t-USDC"
+        },
+        {
+          "address": "0xDa1CD1711743e57Dd57102E9e61b75f3587703da",
+          "weight": "null",
+          "symbol": "bb-t-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7c82A23B4C48D796dee36A9cA215b641C6a8709d": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7c82a23b4c48d796dee36a9ca215b641c6a8709d.png",
+      "0xae646817e458C0bE890b81e8d880206710E3c44e": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae646817e458c0be890b81e8d880206710e3c44e.png",
+      "0xDa1CD1711743e57Dd57102E9e61b75f3587703da": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xda1cd1711743e57dd57102e9e61b75f3587703da.png"
+    }
+  },
+  {
+    "address": "0xDd3b4161D2a4c609884E20Ed71b4e85BE44572E6",
+    "network": 137,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x216690738aac4aa0c4770253ca26a28f0115c595000000000000000000000b2c",
+      "address": "0x216690738Aac4aa0C4770253CA26a28f0115c595",
+      "poolType": "ComposableStable",
+      "symbol": "stMATIC-bb-a-WMATIC-BPT",
+      "tokens": [
+        {
+          "address": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+          "weight": "null",
+          "symbol": "stMATIC"
+        },
+        {
+          "address": "0xE4885Ed2818Cc9E840A25f94F9b2A28169D1AEA7",
+          "weight": "null",
+          "symbol": "bb-a-WMATIC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+      "0xE4885Ed2818Cc9E840A25f94F9b2A28169D1AEA7": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7.png"
+    }
+  },
+  {
+    "address": "0x6b641e334f63f0D882538Fe189efC0702d961696",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xb371aa09f5a110ab69b39a84b5469d29f9b22b76000000000000000000000b37",
+      "address": "0xb371aA09F5a110AB69b39A84B5469d29f9b22B76",
+      "poolType": "ComposableStable",
+      "symbol": "bb-am-USD",
+      "tokens": [
+        {
+          "address": "0x89B28A9494589b09dbcCb69911c189f74FdAdc5a",
+          "weight": "null",
+          "symbol": "bb-a-USDC"
+        },
+        {
+          "address": "0xa5fE91dde37D8BF2daCACC0168B115D28eD03f84",
+          "weight": "null",
+          "symbol": "bb-a-DAI"
+        },
+        {
+          "address": "0xb59BE8f3C85A9DD6E2899103B6fbF6ea405B99a4",
+          "weight": "null",
+          "symbol": "bb-a-USDT"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x89B28A9494589b09dbcCb69911c189f74FdAdc5a": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x89b28a9494589b09dbccb69911c189f74fdadc5a.png",
+      "0xa5fE91dde37D8BF2daCACC0168B115D28eD03f84": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa5fe91dde37d8bf2dacacc0168b115d28ed03f84.png",
+      "0xb59BE8f3C85A9DD6E2899103B6fbF6ea405B99a4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb59be8f3c85a9dd6e2899103b6fbf6ea405b99a4.png"
+    }
+  },
+  {
+    "address": "0x47D7269829Ba9571D98Eb6DDc34e9C8f1A4C327f",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x4a77ef015ddcd972fd9ba2c7d5d658689d090f1a000000000000000000000b38",
+      "address": "0x4a77eF015ddcd972fd9BA2C7D5D658689D090f1A",
+      "poolType": "ComposableStable",
+      "symbol": "wstETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0x43894DE14462B421372bCFe445fA51b1b4A0Ff3D",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd.png",
+      "0x43894DE14462B421372bCFe445fA51b1b4A0Ff3D": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43894de14462b421372bcfe445fa51b1b4a0ff3d.png"
+    }
+  },
+  {
+    "address": "0x455f20c54b5712a84454468c7831f7c431aeEB1C",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0xe19ed40a47f9b0cea4ca6d372df66107758913ec000000000000000000000b41",
+      "address": "0xe19ed40A47F9B0CEA4ca6D372dF66107758913Ec",
+      "poolType": "ComposableStable",
+      "symbol": "2BRL (BRZ)",
+      "tokens": [
+        {
+          "address": "0x491a4eB4f1FC3BfF8E1d2FC856a6A46663aD556f",
+          "weight": "null",
+          "symbol": "BRZ"
+        },
+        {
+          "address": "0xf2f77FE7b8e66571E0fca7104c4d670BF1C8d722",
+          "weight": "null",
+          "symbol": "jBRL"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x491a4eB4f1FC3BfF8E1d2FC856a6A46663aD556f": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x491a4eb4f1fc3bff8e1d2fc856a6a46663ad556f.png",
+      "0xf2f77FE7b8e66571E0fca7104c4d670BF1C8d722": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf2f77fe7b8e66571e0fca7104c4d670bf1c8d722.png"
+    }
+  },
+  {
+    "address": "0x416d15C36c6DaAd2b9410B79aE557e6F07DcB642",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0xd00f9ca46ce0e4a63067c4657986f0167b0de1e5000000000000000000000b42",
+      "address": "0xD00f9Ca46ce0E4A63067c4657986f0167b0De1E5",
+      "poolType": "ComposableStable",
+      "symbol": "frxETH-bb-a-WETH",
+      "tokens": [
+        {
+          "address": "0x43894DE14462B421372bCFe445fA51b1b4A0Ff3D",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xEe327F889d5947c1dc1934Bb208a1E792F953E96",
+          "weight": "null",
+          "symbol": "frxETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x43894DE14462B421372bCFe445fA51b1b4A0Ff3D": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43894de14462b421372bcfe445fa51b1b4a0ff3d.png",
+      "0xEe327F889d5947c1dc1934Bb208a1E792F953E96": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xee327f889d5947c1dc1934bb208a1e792f953e96.png"
+    }
+  },
+  {
+    "address": "0xBAdF0c8702B7Cb06bBEC351d18071804759e312c",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0x3efb91c4f9b103ee45885695c67794591916f34e000200000000000000000b43",
+      "address": "0x3Efb91C4F9B103Ee45885695C67794591916F34E",
+      "poolType": "Weighted",
+      "symbol": "2BRL-bbamUSD",
+      "tokens": [
+        {
+          "address": "0xb371aA09F5a110AB69b39A84B5469d29f9b22B76",
+          "weight": "0.5",
+          "symbol": "bb-am-USD"
+        },
+        {
+          "address": "0xe19ed40A47F9B0CEA4ca6D372dF66107758913Ec",
+          "weight": "0.5",
+          "symbol": "2BRL (BRZ)"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xb371aA09F5a110AB69b39A84B5469d29f9b22B76": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb371aa09f5a110ab69b39a84b5469d29f9b22b76.png",
+      "0xe19ed40A47F9B0CEA4ca6D372dF66107758913Ec": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe19ed40a47f9b0cea4ca6d372df66107758913ec.png"
+    }
+  },
+  {
+    "address": "0x539D6eDbd16F2F069A06716416C3a6E98cC29DD0",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1683038387,
+    "pool": {
+      "id": "0x924ec7ed38080e40396c46f6206a6d77d0b9f72d00020000000000000000072a",
+      "address": "0x924EC7ed38080E40396c46F6206A6d77D0B9f72d",
+      "poolType": "Weighted",
+      "symbol": "20WMATIC-80LUCHA",
+      "tokens": [
+        {
+          "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+          "weight": "0.2",
+          "symbol": "WMATIC"
+        },
+        {
+          "address": "0x6749441Fdc8650b5b5a854ed255C82EF361f1596",
+          "weight": "0.8",
+          "symbol": "LUCHA"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+      "0x6749441Fdc8650b5b5a854ed255C82EF361f1596": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/137_0x6749441fdc8650b5b5a854ed255c82ef361f1596.png"
+    }
+  },
+  {
+    "address": "0xecF0a26a290cbf3DDBAB7eC5Fb44Ef5A294cAc18",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1684175447,
+    "pool": {
+      "id": "0x8fbd0f8e490735cfc3abf4f29cbddd5c3289b9a7000000000000000000000b5b",
+      "address": "0x8fbd0F8e490735CFc3AbF4f29cBdDD5c3289b9A7",
+      "poolType": "ComposableStable",
+      "symbol": "FRAX-bb-am-USD",
+      "tokens": [
+        {
+          "address": "0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89",
+          "weight": "null",
+          "symbol": "FRAX"
+        },
+        {
+          "address": "0xb371aA09F5a110AB69b39A84B5469d29f9b22B76",
+          "weight": "null",
+          "symbol": "bb-am-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x45c32fa6df82ead1e2ef74d17b76547eddfaff89.png",
+      "0xb371aA09F5a110AB69b39A84B5469d29f9b22B76": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb371aa09f5a110ab69b39a84b5469d29f9b22b76.png"
+    }
+  },
+  {
+    "address": "0x6f06b425e1bc11FC486C308c22e503d188525F06",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xb266ac3b7c98d7bcb28731dac0ef42dba1b276be000000000000000000000be4",
+      "address": "0xb266aC3b7C98D7Bcb28731Dac0eF42DbA1b276bE",
+      "poolType": "ComposableStable",
+      "symbol": "truMATIC-bb-a-WMATIC-BPT",
+      "tokens": [
+        {
+          "address": "0xb0C830DCeB4EF55A60192472c20C8bf19dF03488",
+          "weight": "null",
+          "symbol": "bb-a-WMATIC"
+        },
+        {
+          "address": "0xC1381c17d29A22dF5c3015C3D83ebd90AbD0e6b3",
+          "weight": "null",
+          "symbol": "fxTruMATIC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xb0C830DCeB4EF55A60192472c20C8bf19dF03488": "",
+      "0xC1381c17d29A22dF5c3015C3D83ebd90AbD0e6b3": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc1381c17d29a22df5c3015c3d83ebd90abd0e6b3.png"
+    }
+  },
+  {
+    "address": "0x24E8787B4AC5325Fd082BC30b9fe7eb2F01304c7",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xac2cae8d2f78a4a8f92f20dbe74042cd0a8d5af3000000000000000000000be2",
+      "address": "0xAC2CaE8D2f78A4a8F92f20dbe74042Cd0a8d5Af3",
+      "poolType": "ComposableStable",
+      "symbol": "stMATIC-bb-a-WMATIC-BPT",
+      "tokens": [
+        {
+          "address": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+          "weight": "null",
+          "symbol": "stMATIC"
+        },
+        {
+          "address": "0xb0C830DCeB4EF55A60192472c20C8bf19dF03488",
+          "weight": "null",
+          "symbol": "bb-a-WMATIC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+      "0xb0C830DCeB4EF55A60192472c20C8bf19dF03488": ""
+    }
+  },
+  {
+    "address": "0xb7b9B9D35e7F9E324C762235FB69848175C03A19",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x402cfdb7781fa85d52f425352661128250b79e12000000000000000000000be3",
+      "address": "0x402cFDb7781fa85d52F425352661128250B79e12",
+      "poolType": "ComposableStable",
+      "symbol": "MaticX-bb-a-WMATIC-BPT",
+      "tokens": [
+        {
+          "address": "0xb0C830DCeB4EF55A60192472c20C8bf19dF03488",
+          "weight": "null",
+          "symbol": "bb-a-WMATIC"
+        },
+        {
+          "address": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
+          "weight": "null",
+          "symbol": "MaticX"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xb0C830DCeB4EF55A60192472c20C8bf19dF03488": "",
+      "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png"
+    }
+  },
+  {
+    "address": "0x735B275a567F6c921c82F83D4515beC1F72038D3",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x9321e2250767d79bab5aa06daa8606a2b3b7b4c5000000000000000000000bf4",
+      "address": "0x9321e2250767D79bAb5aA06DAa8606A2B3B7B4C5",
+      "poolType": "ComposableStable",
+      "symbol": "bb-t-USD",
+      "tokens": [
+        {
+          "address": "0x7c82A23B4C48D796dee36A9cA215b641C6a8709d",
+          "weight": "null",
+          "symbol": "bb-t-USDT"
+        },
+        {
+          "address": "0xae646817e458C0bE890b81e8d880206710E3c44e",
+          "weight": "null",
+          "symbol": "bb-t-USDC"
+        },
+        {
+          "address": "0xDa1CD1711743e57Dd57102E9e61b75f3587703da",
+          "weight": "null",
+          "symbol": "bb-t-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x7c82A23B4C48D796dee36A9cA215b641C6a8709d": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7c82a23b4c48d796dee36a9ca215b641c6a8709d.png",
+      "0xae646817e458C0bE890b81e8d880206710E3c44e": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae646817e458c0be890b81e8d880206710e3c44e.png",
+      "0xDa1CD1711743e57Dd57102E9e61b75f3587703da": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xda1cd1711743e57dd57102e9e61b75f3587703da.png"
+    }
+  },
+  {
+    "address": "0x224989bC31286f0E6Dd6F32C0E475BbD4579A976",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x03090a9811181a2afe830a3a0b467698ccf3a8b1000000000000000000000bf5",
+      "address": "0x03090a9811181A2AfE830a3a0B467698CcF3a8b1",
+      "poolType": "ComposableStable",
+      "symbol": "bb-am-usd",
+      "tokens": [
+        {
+          "address": "0x230eCdB2a7CEE56d6889965A023AA0473D6dA507",
+          "weight": "null",
+          "symbol": "bb-a-USDT"
+        },
+        {
+          "address": "0x63cE19cCd39930725b8a3D2733627804718Ab83D",
+          "weight": "null",
+          "symbol": "bb-a-DAI"
+        },
+        {
+          "address": "0x89bb15076C9f2D86aa98ec6cFfC1a71e31c38953",
+          "weight": "null",
+          "symbol": "bb-a-USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x230eCdB2a7CEE56d6889965A023AA0473D6dA507": "",
+      "0x63cE19cCd39930725b8a3D2733627804718Ab83D": "",
+      "0x89bb15076C9f2D86aa98ec6cFfC1a71e31c38953": ""
+    }
+  },
+  {
+    "address": "0xEE3cc827EF3e7a00a728Fd52199cd5A6e336361D",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xf42ed61450458ee4620f5ef4f29adb25a6ef0fb6000000000000000000000bf8",
+      "address": "0xF42ED61450458eE4620F5eF4f29adB25a6Ef0fb6",
+      "poolType": "ComposableStable",
+      "symbol": "frxETH-bb-a-WETH",
+      "tokens": [
+        {
+          "address": "0x25e57F4612912614e6C99616Bd2aBB9b5Ae71E99",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xEe327F889d5947c1dc1934Bb208a1E792F953E96",
+          "weight": "null",
+          "symbol": "frxETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x25e57F4612912614e6C99616Bd2aBB9b5Ae71E99": "",
+      "0xEe327F889d5947c1dc1934Bb208a1E792F953E96": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xee327f889d5947c1dc1934bb208a1e792f953e96.png"
+    }
+  },
+  {
+    "address": "0x1EcB261dc3496675c54514e44deA2a5115aEcb38",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xd2f3b9e67c69762dd1c88f1d3dadd1649a190761000200000000000000000bf7",
+      "address": "0xD2f3B9E67C69762dd1c88F1D3dADD1649a190761",
+      "poolType": "Weighted",
+      "symbol": "2BRLUSD-boosted",
+      "tokens": [
+        {
+          "address": "0x03090a9811181A2AfE830a3a0B467698CcF3a8b1",
+          "weight": "0.5",
+          "symbol": "bb-am-usd"
+        },
+        {
+          "address": "0x42942cDeC85078Cf0e28e9CB5ACd40CB53997Ed6",
+          "weight": "0.5",
+          "symbol": "2BRL (BRZ)"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x03090a9811181A2AfE830a3a0B467698CcF3a8b1": "",
+      "0x42942cDeC85078Cf0e28e9CB5ACd40CB53997Ed6": ""
+    }
+  },
+  {
+    "address": "0xdb218DC1394BbD787bb059dBd9F7E41063e16374",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xa8bf1c584519be0184311c48adbdc4c15cb2e8c1000000000000000000000bf6",
+      "address": "0xA8BF1C584519bE0184311C48AdBDc4c15cb2E8C1",
+      "poolType": "ComposableStable",
+      "symbol": "FRAX-bb-am-USD",
+      "tokens": [
+        {
+          "address": "0x03090a9811181A2AfE830a3a0B467698CcF3a8b1",
+          "weight": "null",
+          "symbol": "bb-am-usd"
+        },
+        {
+          "address": "0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89",
+          "weight": "null",
+          "symbol": "FRAX"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x03090a9811181A2AfE830a3a0B467698CcF3a8b1": "",
+      "0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x45c32fa6df82ead1e2ef74d17b76547eddfaff89.png"
+    }
+  },
+  {
+    "address": "0x95Ee4c90aC8AaFbAe0DfE18F08a290b59eacbc1b",
+    "network": 137,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xab269164a10fab22bc87c39946da06c870b172d6000000000000000000000bfc",
+      "address": "0xAB269164a10faB22BC87c39946da06C870B172D6",
+      "poolType": "ComposableStable",
+      "symbol": "wstETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0x25e57F4612912614e6C99616Bd2aBB9b5Ae71E99",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd.png",
+      "0x25e57F4612912614e6C99616Bd2aBB9b5Ae71E99": ""
+    }
+  },
+  {
+    "address": "0x54f220a891f468629027C3Cc8A58722D4F576402",
+    "network": 1101,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0x1d0a8a31cdb04efac3153237526fb15cc65a252000000000000000000000000f",
+      "address": "0x1d0A8a31CDb04efAC3153237526Fb15cc65A2520",
+      "poolType": "ComposableStable",
+      "symbol": "B-rETH-STABLE",
+      "tokens": [
+        {
+          "address": "0x4F9A0e7FD2Bf6067db6994CF12E4495Df938E6e9",
+          "weight": "null",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4F9A0e7FD2Bf6067db6994CF12E4495Df938E6e9": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9.png",
+      "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb23c20efce6e24acca0cef9b7b7aa196b84ec942.png"
+    }
+  },
+  {
+    "address": "0xce99399fb4De36056A6831b159572E271360ea40",
+    "network": 1101,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0xe1f2c039a68a216de6dd427be6c60decf405762a00000000000000000000000e",
+      "address": "0xe1F2c039a68A216dE6DD427Be6c60dEcf405762A",
+      "poolType": "ComposableStable",
+      "symbol": "B-wstETH-STABLE",
+      "tokens": [
+        {
+          "address": "0x4F9A0e7FD2Bf6067db6994CF12E4495Df938E6e9",
+          "weight": "null",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
+          "weight": "null",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x4F9A0e7FD2Bf6067db6994CF12E4495Df938E6e9": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9.png",
+      "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5d8cff95d7a57c0bf50b30b43c7cc0d52825d4a9.png"
+    }
+  },
+  {
+    "address": "0xF7d515DC47d5BD57786494628ed766d6bF31cd39",
+    "network": 1101,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0xdf725fde6e89981fb30d9bf999841ac2c160b512000000000000000000000010",
+      "address": "0xDF725FdE6E89981Fb30D9bF999841aC2C160b512",
+      "poolType": "ComposableStable",
+      "symbol": "B-wstETH/rETH-STABLE",
+      "tokens": [
+        {
+          "address": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5d8cff95d7a57c0bf50b30b43c7cc0d52825d4a9.png",
+      "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb23c20efce6e24acca0cef9b7b7aa196b84ec942.png"
+    }
+  },
+  {
+    "address": "0xc85679E41f1F98E694D9F8983fdD484F98F2eB02",
+    "network": 1101,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0x9e2d87f904862671eb49cb358e74284762cc9f42000200000000000000000013",
+      "address": "0x9e2D87f904862671eb49cB358E74284762cC9F42",
+      "poolType": "Weighted",
+      "symbol": "B-wstETH/bboUSD",
+      "tokens": [
+        {
+          "address": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xe274c9deb6ed34cfe4130F8D0A8a948deA5bB286",
+          "weight": "0.5",
+          "symbol": "bb-o-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5d8cff95d7a57c0bf50b30b43c7cc0d52825d4a9.png",
+      "0xe274c9deb6ed34cfe4130F8D0A8a948deA5bB286": ""
+    }
+  },
+  {
+    "address": "0x6823DcA6D70061F2AE2AAA21661795A2294812bF",
+    "network": 42161,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1650405644,
+    "pool": {
+      "id": "0xcc65a812ce382ab909a11e434dbf75b34f1cc59d000200000000000000000001",
+      "address": "0xcC65A812ce382aB909a11E434dbf75B34f1cc59D",
+      "poolType": "Weighted",
+      "symbol": "B-60BAL-40WETH",
+      "tokens": [
+        {
+          "address": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
+          "weight": "0.6",
+          "symbol": "BAL"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "0.4",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8/logo.png",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  },
+  {
+    "address": "0x0EDF6cDd81BC3471C053341B7D8Dfd1Cb367AD93",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xb3028ca124b80cfe6e9ca57b70ef2f0ccc41ebd40002000000000000000000ba",
+      "address": "0xb3028Ca124B80CFE6E9CA57B70eF2F0CCC41eBd4",
+      "poolType": "Weighted",
+      "symbol": "50MAGIC-50USDC",
+      "tokens": [
+        {
+          "address": "0x539bdE0d7Dbd336b79148AA742883198BBF60342",
+          "weight": "0.5",
+          "symbol": "MAGIC"
+        },
+        {
+          "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "weight": "0.5",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x539bdE0d7Dbd336b79148AA742883198BBF60342": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x539bde0d7dbd336b79148aa742883198bbf60342.png",
+      "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xff970a61a04b1ca14834a43f5de4533ebddb5cc8.png"
+    }
+  },
+  {
+    "address": "0x6f825C8bbf67eBb6bc35cf2071daCD2864C3258E",
+    "network": 42161,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1664196539,
+    "pool": {
+      "id": "0xfb5e6d0c1dfed2ba000fbc040ab8df3615ac329c000000000000000000000159",
+      "address": "0xFB5e6d0c1DfeD2BA000fBC040Ab8DF3615AC329c",
+      "poolType": "ComposableStable",
+      "symbol": "B-stETH-Stable",
+      "tokens": [
+        {
+          "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5979D7b546E38E414F7E9822514be443A4800529": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  },
+  {
+    "address": "0x87ae77A8270F223656D9dC40AD51aabfAB424b30",
+    "network": 42161,
+    "isKilled": true,
+    "relativeWeightCap": "null",
+    "addedTimestamp": 1664196539,
+    "pool": {
+      "id": "0x178e029173417b1f9c8bc16dcec6f697bc323746000200000000000000000158",
+      "address": "0x178E029173417b1F9C8bC16DCeC6f697bC323746",
+      "poolType": "Weighted",
+      "symbol": "50WSTETH-50USDC",
+      "tokens": [
+        {
+          "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+          "weight": "0.5",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "weight": "0.5",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5979D7b546E38E414F7E9822514be443A4800529": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+      "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xff970a61a04b1ca14834a43f5de4533ebddb5cc8.png"
+    }
+  },
+  {
+    "address": "0x519cCe718FCD11AC09194CFf4517F12D263BE067",
+    "network": 42161,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1673913107,
+    "pool": {
+      "id": "0x36bf227d6bac96e2ab1ebb5492ecec69c691943f000200000000000000000316",
+      "address": "0x36bf227d6BaC96e2aB1EbB5492ECec69C691943f",
+      "poolType": "MetaStable",
+      "symbol": "B-wstETH-WETH-Stable",
+      "tokens": [
+        {
+          "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5979D7b546E38E414F7E9822514be443A4800529": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  },
+  {
+    "address": "0xDf464348c4EC2Bf0e5D6926b9f707c8e02301adf",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x36bf227d6bac96e2ab1ebb5492ecec69c691943f000200000000000000000316",
+      "address": "0x36bf227d6BaC96e2aB1EbB5492ECec69C691943f",
+      "poolType": "MetaStable",
+      "symbol": "B-wstETH-WETH-Stable",
+      "tokens": [
+        {
+          "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5979D7b546E38E414F7E9822514be443A4800529": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  },
+  {
+    "address": "0x09D1036B04ef49BC155D258D7360FA7aE8F5B84d",
+    "network": 42161,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x077794c30afeccdf5ad2abc0588e8cee7197b71a000000000000000000000352",
+      "address": "0x077794c30AFECcdF5ad2Abc0588E8CEE7197b71a",
+      "poolType": "ComposableStable",
+      "symbol": "bb-rf-USD-BPT",
+      "tokens": [
+        {
+          "address": "0x5BAe72B75CaAb1f260D21BC028c630140607D6e8",
+          "weight": "null",
+          "symbol": "bb-rf-USDC"
+        },
+        {
+          "address": "0x894c82800526E0391E709c0983a5AeA3718b7F6D",
+          "weight": "null",
+          "symbol": "bb-rf-USDT"
+        },
+        {
+          "address": "0xe1Fb90D0d3b47E551d494d7eBe8f209753526B01",
+          "weight": "null",
+          "symbol": "bb-rf-DAI"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5BAe72B75CaAb1f260D21BC028c630140607D6e8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5bae72b75caab1f260d21bc028c630140607d6e8.png",
+      "0x894c82800526E0391E709c0983a5AeA3718b7F6D": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x894c82800526e0391e709c0983a5aea3718b7f6d.png",
+      "0xe1Fb90D0d3b47E551d494d7eBe8f209753526B01": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe1fb90d0d3b47e551d494d7ebe8f209753526b01.png"
+    }
+  },
+  {
+    "address": "0x19ff30f9B2d32bfb0F21f2DB6c6A3A8604Eb8C2B",
+    "network": 42161,
+    "isKilled": true,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1680086867,
+    "pool": {
+      "id": "0x32df62dc3aed2cd6224193052ce665dc181658410002000000000000000003bd",
+      "address": "0x32dF62dc3aEd2cD6224193052Ce665DC18165841",
+      "poolType": "Weighted",
+      "symbol": "RDNT-WETH",
+      "tokens": [
+        {
+          "address": "0x3082CC23568eA640225c2467653dB90e9250AaA0",
+          "weight": "0.8",
+          "symbol": "RDNT"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3082CC23568eA640225c2467653dB90e9250AaA0": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x3082CC23568eA640225c2467653dB90e9250AaA0/logo.png",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  },
+  {
+    "address": "0x8135d6AbFd42707A87A7b94c5CFA3529f9b432AD",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0x32df62dc3aed2cd6224193052ce665dc181658410002000000000000000003bd",
+      "address": "0x32dF62dc3aEd2cD6224193052Ce665DC18165841",
+      "poolType": "Weighted",
+      "symbol": "RDNT-WETH",
+      "tokens": [
+        {
+          "address": "0x3082CC23568eA640225c2467653dB90e9250AaA0",
+          "weight": "0.8",
+          "symbol": "RDNT"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "0.2",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x3082CC23568eA640225c2467653dB90e9250AaA0": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x3082CC23568eA640225c2467653dB90e9250AaA0/logo.png",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  },
+  {
+    "address": "0x4944b07977A42C15c6a06CF4e204e24c60564104",
+    "network": 42161,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1683715019,
+    "pool": {
+      "id": "0xcba9ff45cfb9ce238afde32b0148eb82cbe635620000000000000000000003fd",
+      "address": "0xCba9Ff45cfB9cE238AfDE32b0148Eb82CbE63562",
+      "poolType": "ComposableStable",
+      "symbol": "rETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0xDa1CD1711743e57Dd57102E9e61b75f3587703da",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xDa1CD1711743e57Dd57102E9e61b75f3587703da": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xda1cd1711743e57dd57102e9e61b75f3587703da.png",
+      "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png"
+    }
+  },
+  {
+    "address": "0xad2632513bFd805A63aD3e38D24EE10835877d41",
+    "network": 42161,
+    "isKilled": true,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1681342871,
+    "pool": {
+      "id": "0xcba9ff45cfb9ce238afde32b0148eb82cbe635620000000000000000000003fd",
+      "address": "0xCba9Ff45cfB9cE238AfDE32b0148Eb82CbE63562",
+      "poolType": "ComposableStable",
+      "symbol": "rETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0xDa1CD1711743e57Dd57102E9e61b75f3587703da",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xDa1CD1711743e57Dd57102E9e61b75f3587703da": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xda1cd1711743e57dd57102e9e61b75f3587703da.png",
+      "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png"
+    }
+  },
+  {
+    "address": "0x8204b749B808818DEb7957DbD030ceEA44D1FE18",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1682430623,
+    "pool": {
+      "id": "0xd3d5d45f4edf82ba0dfaf061d230766032a10e07000200000000000000000413",
+      "address": "0xD3D5d45f4Edf82ba0dFaf061d230766032a10e07",
+      "poolType": "Weighted",
+      "symbol": "50STG-50bbaUSD",
+      "tokens": [
+        {
+          "address": "0x6694340fc020c5E6B96567843da2df01b2CE1eb6",
+          "weight": "0.5",
+          "symbol": "STG"
+        },
+        {
+          "address": "0xEE02583596AEE94ccCB7e8ccd3921d955f17982A",
+          "weight": "0.5",
+          "symbol": "bb-a-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6694340fc020c5E6B96567843da2df01b2CE1eb6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6694340fc020c5e6b96567843da2df01b2ce1eb6.png",
+      "0xEE02583596AEE94ccCB7e8ccd3921d955f17982A": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xee02583596aee94cccb7e8ccd3921d955f17982a.png"
+    }
+  },
+  {
+    "address": "0xc4b6cc9A444337b1Cb8cBbDD9de4d983f609C391",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1684791827,
+    "pool": {
+      "id": "0x542f16da0efb162d20bf4358efa095b70a100f9e000000000000000000000436",
+      "address": "0x542F16DA0efB162D20bF4358EfA095B70A100f9E",
+      "poolType": "ComposableStable",
+      "symbol": "2BTC",
+      "tokens": [
+        {
+          "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+          "weight": "null",
+          "symbol": "WBTC"
+        },
+        {
+          "address": "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40",
+          "weight": "null",
+          "symbol": "tBTC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+      "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40.png"
+    }
+  },
+  {
+    "address": "0xa8D974288Fe44ACC329D7d7a179707D27Ec4dd1c",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1684791827,
+    "pool": {
+      "id": "0xc9f52540976385a84bf416903e1ca3983c539e34000200000000000000000434",
+      "address": "0xc9f52540976385A84BF416903e1Ca3983c539E34",
+      "poolType": "Weighted",
+      "symbol": "50tBTC-50WETH",
+      "tokens": [
+        {
+          "address": "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40",
+          "weight": "0.5",
+          "symbol": "tBTC"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40.png",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  },
+  {
+    "address": "0x8F7a0F9cf545DB78BF5120D3DBea7DE9c6220c10",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1685385851,
+    "pool": {
+      "id": "0xa231aea07bb5e79ae162f95903806fc5ad65ff1100020000000000000000043f",
+      "address": "0xa231aEa07Bb5e79aE162f95903806FC5AD65fF11",
+      "poolType": "Weighted",
+      "symbol": "50DFX-50WETH",
+      "tokens": [
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "0.5",
+          "symbol": "WETH"
+        },
+        {
+          "address": "0xA4914B824eF261D4ED0Ccecec29500862d57c0a1",
+          "weight": "0.5",
+          "symbol": "DFX"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png",
+      "0xA4914B824eF261D4ED0Ccecec29500862d57c0a1": "https://assets.coingecko.com/coins/images/14091/large/DFX.png?1614320944"
+    }
+  },
+  {
+    "address": "0xd758454BDF4Df7Ad85f7538DC9742648EF8e6d0A",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1686659711,
+    "pool": {
+      "id": "0x8d333f82e0693f53fa48c40d5d4547142e907e1d000200000000000000000437",
+      "address": "0x8d333f82e0693f53fA48c40d5D4547142E907e1D",
+      "poolType": "Weighted",
+      "symbol": "80PAL-20OHM",
+      "tokens": [
+        {
+          "address": "0xa7997F0eC9fa54E89659229fB26537B6A725b798",
+          "weight": "0.8",
+          "symbol": "PAL"
+        },
+        {
+          "address": "0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028",
+          "weight": "0.2",
+          "symbol": "OHM"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xa7997F0eC9fa54E89659229fB26537B6A725b798": "",
+      "0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028": "https://assets.coingecko.com/coins/images/14483/large/token_OHM_%281%29.png?1628311611"
+    }
+  },
+  {
+    "address": "0x6ba66967B0723718d616ad5F293c2AE6d7b0FCAE",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0xce2da1d3e5b5e4e1913f9ff65ee029d38682d8b900020000000000000000044e",
+      "address": "0xCE2Da1D3e5b5e4E1913F9fF65eE029d38682d8b9",
+      "poolType": "Weighted",
+      "symbol": "B-50ACID-50WETH",
+      "tokens": [
+        {
+          "address": "0x29C1EA5ED7af53094b1a79eF60d20641987c867e",
+          "weight": "0.5",
+          "symbol": "ACID"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "0.5",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x29C1EA5ED7af53094b1a79eF60d20641987c867e": "https://assets.coingecko.com/coins/images/29418/large/acid_200_200.png?1678696816",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  },
+  {
+    "address": "0x25869f277f474FA9459F40F5D4cB0D6A8Ab41967",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0x8bc65eed474d1a00555825c91feab6a8255c2107000000000000000000000453",
+      "address": "0x8bc65Eed474D1A00555825c91FeAb6A8255C2107",
+      "poolType": "ComposableStable",
+      "symbol": "DOLA/USDC BPT",
+      "tokens": [
+        {
+          "address": "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6",
+          "weight": "null",
+          "symbol": "DOLA"
+        },
+        {
+          "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "weight": "null",
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1667738374",
+      "0xaf88d065e77c8cC2239327C5EDb3A432268e5831": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xaf88d065e77c8cc2239327c5edb3a432268e5831.png"
+    }
+  },
+  {
+    "address": "0xacE0D479040231e3c6b17479cFd4444182d521d4",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1687258571,
+    "pool": {
+      "id": "0x567ecfcb22205d279bb8eed3e066989902bf03d5000000000000000000000452",
+      "address": "0x567ECfCB22205D279BB8Eed3E066989902bF03D5",
+      "poolType": "ComposableStable",
+      "symbol": "DOLA/bbaUSD-BPT",
+      "tokens": [
+        {
+          "address": "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6",
+          "weight": "null",
+          "symbol": "DOLA"
+        },
+        {
+          "address": "0xEE02583596AEE94ccCB7e8ccd3921d955f17982A",
+          "weight": "null",
+          "symbol": "bb-a-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1667738374",
+      "0xEE02583596AEE94ccCB7e8ccd3921d955f17982A": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xee02583596aee94cccb7e8ccd3921d955f17982a.png"
+    }
+  },
+  {
+    "address": "0x175407b4710b5A1cB67a37C76859F17fb2ff6672",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "0.02",
+    "addedTimestamp": 1687806647,
+    "pool": {
+      "id": "0xc7fa3a3527435720f0e2a4c1378335324dd4f9b3000200000000000000000459",
+      "address": "0xc7FA3A3527435720f0e2a4c1378335324dd4F9b3",
+      "poolType": "Weighted",
+      "symbol": "55auraBal-45wsteth",
+      "tokens": [
+        {
+          "address": "0x223738a747383d6F9f827d95964e4d8E8AC754cE",
+          "weight": "0.55",
+          "symbol": "auraBAL"
+        },
+        {
+          "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+          "weight": "0.45",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x223738a747383d6F9f827d95964e4d8E8AC754cE": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x223738a747383d6f9f827d95964e4d8e8ac754ce.png",
+      "0x5979D7b546E38E414F7E9822514be443A4800529": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png"
+    }
+  },
+  {
+    "address": "0xD2C2b1C0F8Ad6E653eD7064fa7bAd7a22De8B249",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x26e5c5e2b48815b59640a1a82ac3c2249188daf4000000000000000000000476",
+      "address": "0x26e5C5e2b48815b59640a1a82ac3C2249188Daf4",
+      "poolType": "ComposableStable",
+      "symbol": "alETH/wstETH-BPT",
+      "tokens": [
+        {
+          "address": "0x17573150d67d820542EFb24210371545a4868B03",
+          "weight": "null",
+          "symbol": "alETH"
+        },
+        {
+          "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+          "weight": "null",
+          "symbol": "wstETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x17573150d67d820542EFb24210371545a4868B03": "",
+      "0x5979D7b546E38E414F7E9822514be443A4800529": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png"
+    }
+  },
+  {
+    "address": "0xCe540832f7c790d25345Aa19FB1Db3cfDEA04611",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xfa92d9dd808d0e8d68079bdc7f01e74658e1ef15000000000000000000000477",
+      "address": "0xfA92D9Dd808D0E8D68079BDc7f01E74658E1EF15",
+      "poolType": "ComposableStable",
+      "symbol": "alETH/rETH-BPT",
+      "tokens": [
+        {
+          "address": "0x17573150d67d820542EFb24210371545a4868B03",
+          "weight": "null",
+          "symbol": "alETH"
+        },
+        {
+          "address": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x17573150d67d820542EFb24210371545a4868B03": "",
+      "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png"
+    }
+  },
+  {
+    "address": "0xb12ADA23eE766bd6b596E2bE556ea2046758b87c",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xbe0f30217be1e981add883848d0773a86d2d2cd4000000000000000000000471",
+      "address": "0xBe0f30217BE1e981aDD883848D0773A86d2d2CD4",
+      "poolType": "ComposableStable",
+      "symbol": "rETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0xaD28940024117B442a9EFB6D0f25C8B59e1c950B",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        },
+        {
+          "address": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0xaD28940024117B442a9EFB6D0f25C8B59e1c950B": "",
+      "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png"
+    }
+  },
+  {
+    "address": "0x80aed5C5C683FEC86817C98da334DD72424E7297",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0x45c4d1376943ab28802b995acffc04903eb5223f000000000000000000000470",
+      "address": "0x45C4D1376943Ab28802B995aCfFC04903Eb5223f",
+      "poolType": "ComposableStable",
+      "symbol": "wstETH-bb-a-WETH-BPT",
+      "tokens": [
+        {
+          "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xaD28940024117B442a9EFB6D0f25C8B59e1c950B",
+          "weight": "null",
+          "symbol": "bb-a-WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x5979D7b546E38E414F7E9822514be443A4800529": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+      "0xaD28940024117B442a9EFB6D0f25C8B59e1c950B": ""
+    }
+  },
+  {
+    "address": "0x9ab40B6e1330Ce70B9e07cD691f281c1539944E6",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1689617291,
+    "pool": {
+      "id": "0xc6eee8cb7643ec2f05f46d569e9ec8ef8b41b389000000000000000000000475",
+      "address": "0xc6EeE8cb7643eC2F05F46d569e9eC8EF8b41b389",
+      "poolType": "ComposableStable",
+      "symbol": "bb-a-USD",
+      "tokens": [
+        {
+          "address": "0x6CB787a419c3e6Ee2e9FF365856c29CD10659113",
+          "weight": "null",
+          "symbol": "bb-a-DAI"
+        },
+        {
+          "address": "0xbD724Eb087d4cc0f61a5fED1fFFaF937937E14DE",
+          "weight": "null",
+          "symbol": "bb-a-USDC"
+        },
+        {
+          "address": "0xc46be4B8Bb6B5A3d3120660efae9C5416318ED40",
+          "weight": "null",
+          "symbol": "bb-a-USDT"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6CB787a419c3e6Ee2e9FF365856c29CD10659113": "",
+      "0xbD724Eb087d4cc0f61a5fED1fFFaF937937E14DE": "",
+      "0xc46be4B8Bb6B5A3d3120660efae9C5416318ED40": ""
+    }
+  },
+  {
+    "address": "0xCe3a024bAF36C91d315722B093928020a4F56622",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0x00fcd3d55085e998e291a0005cedecf58ac14c4000020000000000000000047f",
+      "address": "0x00FCD3d55085e998e291a0005cedeCF58aC14c40",
+      "poolType": "Weighted",
+      "symbol": "50STG-50bbaUSD ",
+      "tokens": [
+        {
+          "address": "0x6694340fc020c5E6B96567843da2df01b2CE1eb6",
+          "weight": "0.5",
+          "symbol": "STG"
+        },
+        {
+          "address": "0xc6EeE8cb7643eC2F05F46d569e9eC8EF8b41b389",
+          "weight": "0.5",
+          "symbol": "bb-a-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6694340fc020c5E6B96567843da2df01b2CE1eb6": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6694340fc020c5e6b96567843da2df01b2ce1eb6.png",
+      "0xc6EeE8cb7643eC2F05F46d569e9eC8EF8b41b389": ""
+    }
+  },
+  {
+    "address": "0xBc771929359B1A6386801705e8D185205d8f1CBF",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690227287,
+    "pool": {
+      "id": "0xbbf9d705b75f408cfcaee91da32966124d2c6f7d00000000000000000000047e",
+      "address": "0xbBF9d705b75F408CFCaEE91dA32966124d2c6F7D",
+      "poolType": "ComposableStable",
+      "symbol": "DOLA/bbaUSD-BPT ",
+      "tokens": [
+        {
+          "address": "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6",
+          "weight": "null",
+          "symbol": "DOLA"
+        },
+        {
+          "address": "0xc6EeE8cb7643eC2F05F46d569e9eC8EF8b41b389",
+          "weight": "null",
+          "symbol": "bb-a-USD"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1667738374",
+      "0xc6EeE8cb7643eC2F05F46d569e9eC8EF8b41b389": ""
+    }
+  },
+  {
+    "address": "0x175FAb9C7aB502B9E76E7fca0C9Da618387EBAdA",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690830527,
+    "pool": {
+      "id": "0xa8af146d79ac0bb981e4e0d8b788ec5711b1d5d000000000000000000000047b",
+      "address": "0xA8af146d79aC0BB981E4e0d8b788Ec5711b1d5d0",
+      "poolType": "ComposableStable",
+      "symbol": "BPT-USD+",
+      "tokens": [
+        {
+          "address": "0x117a3d474976274B37B7b94aF5DcAde5c90C6e85",
+          "weight": "null",
+          "symbol": "bb-DAI+"
+        },
+        {
+          "address": "0x284EB68520C8fA83361C1A3a5910aEC7f873C18b",
+          "weight": "null",
+          "symbol": "bb-USD+"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x117a3d474976274B37B7b94aF5DcAde5c90C6e85": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x117a3d474976274b37b7b94af5dcade5c90c6e85.png",
+      "0x284EB68520C8fA83361C1A3a5910aEC7f873C18b": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x284eb68520c8fa83361c1a3a5910aec7f873c18b.png"
+    }
+  },
+  {
+    "address": "0x2Cb5EB92314bf3BFE7977e059A72A806d353fd21",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690830527,
+    "pool": {
+      "id": "0xd6d20527c7b0669989ee082b9d3a1c63af742290000000000000000000000483",
+      "address": "0xd6d20527C7B0669989ee082b9D3A1c63aF742290",
+      "poolType": "ComposableStable",
+      "symbol": "BPT-DOLA-USD+",
+      "tokens": [
+        {
+          "address": "0x284EB68520C8fA83361C1A3a5910aEC7f873C18b",
+          "weight": "null",
+          "symbol": "bb-USD+"
+        },
+        {
+          "address": "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6",
+          "weight": "null",
+          "symbol": "DOLA"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x284EB68520C8fA83361C1A3a5910aEC7f873C18b": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x284eb68520c8fa83361c1a3a5910aec7f873c18b.png",
+      "0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1667738374"
+    }
+  },
+  {
+    "address": "0x56c0626E6E3931af90EbB679A321225180d4b32B",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690830527,
+    "pool": {
+      "id": "0x4a2f6ae7f3e5d715689530873ec35593dc28951b000000000000000000000481",
+      "address": "0x4a2F6Ae7F3e5D715689530873ec35593Dc28951B",
+      "poolType": "ComposableStable",
+      "symbol": "wstETH/rETH/cbETH",
+      "tokens": [
+        {
+          "address": "0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f",
+          "weight": "null",
+          "symbol": "cbETH"
+        },
+        {
+          "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+          "weight": "null",
+          "symbol": "wstETH"
+        },
+        {
+          "address": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+          "weight": "null",
+          "symbol": "rETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1661390066",
+      "0x5979D7b546E38E414F7E9822514be443A4800529": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+      "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png"
+    }
+  },
+  {
+    "address": "0x90DDAa2A6D192Db2F47195d847626F94E940c7Ac",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "1",
+    "addedTimestamp": 1690830527,
+    "pool": {
+      "id": "0x9cebf13bb702f253abf1579294694a1edad00eaa000000000000000000000486",
+      "address": "0x9ceBf13BB702F253AbF1579294694A1eDAD00EAA",
+      "poolType": "ComposableStable",
+      "symbol": "bbaUSDC/bbaUSDCe",
+      "tokens": [
+        {
+          "address": "0x40af308e3d07ec769D85EB80aFb116525fF4aC99",
+          "weight": "null",
+          "symbol": "bb-a-USDCe"
+        },
+        {
+          "address": "0xbD724Eb087d4cc0f61a5fED1fFFaF937937E14DE",
+          "weight": "null",
+          "symbol": "bb-a-USDC"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x40af308e3d07ec769D85EB80aFb116525fF4aC99": "",
+      "0xbD724Eb087d4cc0f61a5fED1fFFaF937937E14DE": ""
+    }
+  },
+  {
+    "address": "0xA4DAA3498677D655E359b0Fc83EbDbd8dbF76a50",
+    "network": 42161,
+    "isKilled": false,
+    "relativeWeightCap": "0.1",
+    "addedTimestamp": 1690830527,
+    "pool": {
+      "id": "0x84a1038d55e887c2abb8cb02ccf4c9d3871c859a000000000000000000000489",
+      "address": "0x84A1038D55e887c2ABb8cB02ccf4C9d3871C859a",
+      "poolType": "ComposableStable",
+      "symbol": "Stafi rETH/WETH",
+      "tokens": [
+        {
+          "address": "0x6CDA1D3D092811b2d48F7476adb59A6239CA9b95",
+          "weight": "null",
+          "symbol": "rETH"
+        },
+        {
+          "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "weight": "null",
+          "symbol": "WETH"
+        }
+      ]
+    },
+    "tokenLogoURIs": {
+      "0x6CDA1D3D092811b2d48F7476adb59A6239CA9b95": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6cda1d3d092811b2d48f7476adb59a6239ca9b95.png",
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png"
+    }
+  }
+]

--- a/apps/balancer-tools/src/lib/balancer/gauges.ts
+++ b/apps/balancer-tools/src/lib/balancer/gauges.ts
@@ -6,85 +6,86 @@ const GAUGE_CACHE: { [address: string]: Gauge } = {};
 const POOL_CACHE: { [id: string]: Pool } = {};
 
 class Token {
-    address: string;
-    weight: string | null;
-    symbol: string;
+  address: string;
+  weight: string | null;
+  symbol: string;
 
-    constructor(data: typeof GAUGE_DATA[0]["pool"]["tokens"][0]) {
-        this.address = data.address;
-        this.weight = data.weight;
-        this.symbol = data.symbol;
-    }
+  constructor(data: (typeof GAUGE_DATA)[0]["pool"]["tokens"][0]) {
+    this.address = data.address;
+    this.weight = data.weight;
+    this.symbol = data.symbol;
+  }
 }
 
-
 export class Pool {
-    id!: string;
-    address!: string;
-    poolType!: string;
-    symbol!: string;
-    tokens!: Token[];
-    gauge?: Gauge;
+  id!: string;
+  address!: string;
+  poolType!: string;
+  symbol!: string;
+  tokens!: Token[];
+  gauge?: Gauge;
 
-    constructor(id: string, associatedGauge?: Gauge) {
-        // Return cached instance if it exists
-        if (POOL_CACHE[id]) {
-            return POOL_CACHE[id];
-        }
-
-        const data = GAUGE_DATA.find(g => g.pool.id === id)?.pool;
-        if (!data) {
-            throw new Error(`Pool with ID ${id} not found`);
-        }
-
-        this.id = data.id;
-        this.address = data.address;
-        this.poolType = data.poolType;
-        this.symbol = data.symbol;
-        this.tokens = data.tokens.map((t: typeof GAUGE_DATA[0]["pool"]["tokens"][0] ) => new Token(t));
-        this.gauge = associatedGauge;
-
-        if (!this.gauge) {
-            const gaugeData = GAUGE_DATA.find(g => g.pool.id === this.id);
-            if (gaugeData) {
-                this.gauge = new Gauge(gaugeData.address);
-                this.gauge.pool = this;
-            }
-        }
-
-        POOL_CACHE[this.id] = this;
+  constructor(id: string, associatedGauge?: Gauge) {
+    // Return cached instance if it exists
+    if (POOL_CACHE[id]) {
+      return POOL_CACHE[id];
     }
+
+    const data = GAUGE_DATA.find((g) => g.pool.id === id)?.pool;
+    if (!data) {
+      throw new Error(`Pool with ID ${id} not found`);
+    }
+
+    this.id = data.id;
+    this.address = data.address;
+    this.poolType = data.poolType;
+    this.symbol = data.symbol;
+    this.tokens = data.tokens.map(
+      (t: (typeof GAUGE_DATA)[0]["pool"]["tokens"][0]) => new Token(t),
+    );
+    this.gauge = associatedGauge;
+
+    if (!this.gauge) {
+      const gaugeData = GAUGE_DATA.find((g) => g.pool.id === this.id);
+      if (gaugeData) {
+        this.gauge = new Gauge(gaugeData.address);
+        this.gauge.pool = this;
+      }
+    }
+
+    POOL_CACHE[this.id] = this;
+  }
 }
 
 export class Gauge {
-    address!: string;
-    network!: number;
-    isKilled?: boolean;
-    addedTimestamp!: number;
-    relativeWeightCap!: string | null;
-    pool!: Pool;
-    tokenLogoURIs?: TokenLogoURIs;
+  address!: string;
+  network!: number;
+  isKilled?: boolean;
+  addedTimestamp!: number;
+  relativeWeightCap!: string | null;
+  pool!: Pool;
+  tokenLogoURIs?: TokenLogoURIs;
 
-    constructor(address: string) {
-        // Return cached instance if it exists
-        if (GAUGE_CACHE[address]) {
-            return GAUGE_CACHE[address];
-        }
-
-        const data = GAUGE_DATA.find(g => g.address.toLowerCase() === address.toLowerCase());
-        if (!data) {
-            throw new Error("Gauge not found for the provided address.");
-        }
-        this.address = data.address;
-        this.network = data.network;
-        this.isKilled = data.isKilled;
-        this.addedTimestamp = data.addedTimestamp;
-        this.relativeWeightCap = data.relativeWeightCap;
-        this.pool = data.pool;
-        this.tokenLogoURIs = data.tokenLogoURIs;
-
-        GAUGE_CACHE[this.address] = this;
+  constructor(address: string) {
+    // Return cached instance if it exists
+    if (GAUGE_CACHE[address]) {
+      return GAUGE_CACHE[address];
     }
+
+    const data = GAUGE_DATA.find(
+      (g) => g.address.toLowerCase() === address.toLowerCase(),
+    );
+    if (!data) {
+      throw new Error("Gauge not found for the provided address.");
+    }
+    this.address = data.address;
+    this.network = data.network;
+    this.isKilled = data.isKilled;
+    this.addedTimestamp = data.addedTimestamp;
+    this.relativeWeightCap = data.relativeWeightCap;
+    this.pool = data.pool;
+    this.tokenLogoURIs = data.tokenLogoURIs;
+
+    GAUGE_CACHE[this.address] = this;
+  }
 }
-
-

--- a/apps/balancer-tools/src/lib/balancer/gauges.ts
+++ b/apps/balancer-tools/src/lib/balancer/gauges.ts
@@ -1,0 +1,90 @@
+import GAUGE_DATA from "#/data/voting-gauges.json";
+
+type TokenLogoURIs = { [key: string]: string | null | undefined };
+
+const GAUGE_CACHE: { [address: string]: Gauge } = {};
+const POOL_CACHE: { [id: string]: Pool } = {};
+
+class Token {
+    address: string;
+    weight: string | null;
+    symbol: string;
+
+    constructor(data: typeof GAUGE_DATA[0]["pool"]["tokens"][0]) {
+        this.address = data.address;
+        this.weight = data.weight;
+        this.symbol = data.symbol;
+    }
+}
+
+
+export class Pool {
+    id!: string;
+    address!: string;
+    poolType!: string;
+    symbol!: string;
+    tokens!: Token[];
+    gauge?: Gauge;
+
+    constructor(id: string, associatedGauge?: Gauge) {
+        // Return cached instance if it exists
+        if (POOL_CACHE[id]) {
+            return POOL_CACHE[id];
+        }
+
+        const data = GAUGE_DATA.find(g => g.pool.id === id)?.pool;
+        if (!data) {
+            throw new Error(`Pool with ID ${id} not found`);
+        }
+
+        this.id = data.id;
+        this.address = data.address;
+        this.poolType = data.poolType;
+        this.symbol = data.symbol;
+        this.tokens = data.tokens.map((t: typeof GAUGE_DATA[0]["pool"]["tokens"][0] ) => new Token(t));
+        this.gauge = associatedGauge;
+
+        if (!this.gauge) {
+            const gaugeData = GAUGE_DATA.find(g => g.pool.id === this.id);
+            if (gaugeData) {
+                this.gauge = new Gauge(gaugeData.address);
+                this.gauge.pool = this;
+            }
+        }
+
+        POOL_CACHE[this.id] = this;
+    }
+}
+
+export class Gauge {
+    address!: string;
+    network!: number;
+    isKilled?: boolean;
+    addedTimestamp!: number;
+    relativeWeightCap!: string | null;
+    pool!: Pool;
+    tokenLogoURIs?: TokenLogoURIs;
+
+    constructor(address: string) {
+        // Return cached instance if it exists
+        if (GAUGE_CACHE[address]) {
+            return GAUGE_CACHE[address];
+        }
+
+        const data = GAUGE_DATA.find(g => g.address.toLowerCase() === address.toLowerCase());
+        if (!data) {
+            throw new Error("Gauge not found for the provided address.");
+        }
+        this.address = data.address;
+        this.network = data.network;
+        this.isKilled = data.isKilled;
+        this.addedTimestamp = data.addedTimestamp;
+        this.relativeWeightCap = data.relativeWeightCap;
+        this.pool = data.pool;
+        this.tokenLogoURIs = data.tokenLogoURIs;
+
+        GAUGE_CACHE[this.address] = this;
+    }
+}
+
+

--- a/apps/balancer-tools/src/lib/coingecko/index.ts
+++ b/apps/balancer-tools/src/lib/coingecko/index.ts
@@ -1,5 +1,3 @@
-import "server-only";
-
 import invariant from "tiny-invariant";
 
 import { fetcher } from "#/utils/fetcher";

--- a/apps/balancer-tools/src/lib/dune.ts
+++ b/apps/balancer-tools/src/lib/dune.ts
@@ -5,7 +5,7 @@ import invariant from "tiny-invariant";
 
 const duneApiKey = process.env.DUNE_API_KEY;
 
-export interface DunePoolData {
+export interface DuneGaugeData {
   pct_votes: number;
   symbol: string;
   votes: number;
@@ -26,7 +26,7 @@ export class DuneAPI {
     roundId: number = 0,
     limitBy: number = 20,
     offsetBy: number = 0,
-  ): Promise<undefined | DunePoolData[] | ErrorReturn> {
+  ): Promise<undefined | DuneGaugeData[] | ErrorReturn> {
     invariant(roundId > 0, "An valid roundId must be passed");
     // https://dune.com/queries/2834602/4732373
     const queryId = 2834602;
@@ -40,7 +40,7 @@ export class DuneAPI {
       .refresh(queryId, parameters)
       .then(
         (executionResult) =>
-          executionResult.result?.rows as unknown as DunePoolData[],
+          executionResult.result?.rows as unknown as DuneGaugeData[],
       )
       .catch((error: { message: string }) => ({ error: error.message }));
   }

--- a/apps/balancer-tools/src/utils/getBaseURL.ts
+++ b/apps/balancer-tools/src/utils/getBaseURL.ts
@@ -1,0 +1,11 @@
+import "server-only";
+
+import { headers } from "next/headers";
+
+export default function getBaseURL() {
+  const headersList = headers();
+  const host = headersList.get("host") || "localhost:3000";
+  const protocol = headersList.get("x-forwarded-proto") || "http";
+
+  return `${protocol}://${host}`;
+}

--- a/packages/gql/src/balancer/__generated__/Arbitrum.server.ts
+++ b/packages/gql/src/balancer/__generated__/Arbitrum.server.ts
@@ -5765,7 +5765,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5830,17 +5830,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Arbitrum.server.ts
+++ b/packages/gql/src/balancer/__generated__/Arbitrum.server.ts
@@ -5830,7 +5830,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5845,7 +5849,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Arbitrum.ts
+++ b/packages/gql/src/balancer/__generated__/Arbitrum.ts
@@ -5832,7 +5832,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5847,7 +5851,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Arbitrum.ts
+++ b/packages/gql/src/balancer/__generated__/Arbitrum.ts
@@ -5767,7 +5767,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5832,17 +5832,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Ethereum.server.ts
+++ b/packages/gql/src/balancer/__generated__/Ethereum.server.ts
@@ -5765,7 +5765,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5830,17 +5830,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Ethereum.server.ts
+++ b/packages/gql/src/balancer/__generated__/Ethereum.server.ts
@@ -5830,7 +5830,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5845,7 +5849,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Ethereum.ts
+++ b/packages/gql/src/balancer/__generated__/Ethereum.ts
@@ -5832,7 +5832,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5847,7 +5851,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Ethereum.ts
+++ b/packages/gql/src/balancer/__generated__/Ethereum.ts
@@ -5767,7 +5767,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5832,17 +5832,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Gnosis.server.ts
+++ b/packages/gql/src/balancer/__generated__/Gnosis.server.ts
@@ -5876,7 +5876,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5941,17 +5941,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Gnosis.server.ts
+++ b/packages/gql/src/balancer/__generated__/Gnosis.server.ts
@@ -5941,7 +5941,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5956,7 +5960,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Gnosis.ts
+++ b/packages/gql/src/balancer/__generated__/Gnosis.ts
@@ -5943,7 +5943,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5958,7 +5962,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Gnosis.ts
+++ b/packages/gql/src/balancer/__generated__/Gnosis.ts
@@ -5878,7 +5878,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5943,17 +5943,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Goerli.server.ts
+++ b/packages/gql/src/balancer/__generated__/Goerli.server.ts
@@ -5765,7 +5765,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5830,17 +5830,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Goerli.server.ts
+++ b/packages/gql/src/balancer/__generated__/Goerli.server.ts
@@ -5830,7 +5830,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5845,7 +5849,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Goerli.ts
+++ b/packages/gql/src/balancer/__generated__/Goerli.ts
@@ -5832,7 +5832,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5847,7 +5851,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Goerli.ts
+++ b/packages/gql/src/balancer/__generated__/Goerli.ts
@@ -5767,7 +5767,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5832,17 +5832,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Optimism.server.ts
+++ b/packages/gql/src/balancer/__generated__/Optimism.server.ts
@@ -5765,7 +5765,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5830,17 +5830,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Optimism.server.ts
+++ b/packages/gql/src/balancer/__generated__/Optimism.server.ts
@@ -5830,7 +5830,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5845,7 +5849,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Optimism.ts
+++ b/packages/gql/src/balancer/__generated__/Optimism.ts
@@ -5832,7 +5832,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5847,7 +5851,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Optimism.ts
+++ b/packages/gql/src/balancer/__generated__/Optimism.ts
@@ -5767,7 +5767,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5832,17 +5832,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Polygon-zkevm.server.ts
+++ b/packages/gql/src/balancer/__generated__/Polygon-zkevm.server.ts
@@ -5765,7 +5765,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5830,17 +5830,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Polygon-zkevm.server.ts
+++ b/packages/gql/src/balancer/__generated__/Polygon-zkevm.server.ts
@@ -5830,7 +5830,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5845,7 +5849,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Polygon-zkevm.ts
+++ b/packages/gql/src/balancer/__generated__/Polygon-zkevm.ts
@@ -5832,7 +5832,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5847,7 +5851,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Polygon-zkevm.ts
+++ b/packages/gql/src/balancer/__generated__/Polygon-zkevm.ts
@@ -5767,7 +5767,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5832,17 +5832,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Polygon.server.ts
+++ b/packages/gql/src/balancer/__generated__/Polygon.server.ts
@@ -5765,7 +5765,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5830,17 +5830,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Polygon.server.ts
+++ b/packages/gql/src/balancer/__generated__/Polygon.server.ts
@@ -5830,7 +5830,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5845,7 +5849,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Polygon.ts
+++ b/packages/gql/src/balancer/__generated__/Polygon.ts
@@ -5832,7 +5832,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5847,7 +5851,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Polygon.ts
+++ b/packages/gql/src/balancer/__generated__/Polygon.ts
@@ -5767,7 +5767,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5832,17 +5832,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Sepolia.server.ts
+++ b/packages/gql/src/balancer/__generated__/Sepolia.server.ts
@@ -5765,7 +5765,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5830,17 +5830,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Sepolia.server.ts
+++ b/packages/gql/src/balancer/__generated__/Sepolia.server.ts
@@ -5830,7 +5830,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5845,7 +5849,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Sepolia.ts
+++ b/packages/gql/src/balancer/__generated__/Sepolia.ts
@@ -5832,7 +5832,11 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
+  pools(
+    where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+  ) {
     id
     address
     name
@@ -5847,7 +5851,12 @@ export const PoolsWherePoolTypeInAndIdDocument = gql`
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
+  pools(
+    where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}
+    orderBy: totalLiquidity
+    orderDirection: desc
+    first: 1000
+  ) {
     id
     address
     name

--- a/packages/gql/src/balancer/__generated__/Sepolia.ts
+++ b/packages/gql/src/balancer/__generated__/Sepolia.ts
@@ -5767,7 +5767,7 @@ export type PoolsWherePoolTypeInAndIdQueryVariables = Exact<{
 }>;
 
 
-export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null }> };
+export type PoolsWherePoolTypeInAndIdQuery = { __typename?: 'Query', pools: Array<{ __typename?: 'Pool', id: string, address: any, name?: string | null, poolType?: string | null, symbol?: string | null, totalLiquidity: any, tokens?: Array<{ __typename?: 'PoolToken', symbol: string }> | null }> };
 
 export type PoolsWherePoolTypeQueryVariables = Exact<{
   poolTypes?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -5832,17 +5832,22 @@ export const PoolsWhereOwnerDocument = gql`
     `;
 export const PoolsWherePoolTypeInAndIdDocument = gql`
     query PoolsWherePoolTypeInAndId($poolId: ID!, $poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes, id: $poolId}) {
+  pools(where: {poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0}) {
     id
     address
     name
     poolType
+    symbol
+    totalLiquidity
+    tokens {
+      symbol
+    }
   }
 }
     `;
 export const PoolsWherePoolTypeDocument = gql`
     query PoolsWherePoolType($poolTypes: [String!] = ["Weighted", "ComposableStable", "Stable", "MetaStable", "Element", "LiquidityBootstrapping", "Linear", "GyroE"]) {
-  pools(where: {poolType_in: $poolTypes}) {
+  pools(where: {poolType_in: $poolTypes, totalLiquidity_gt: 0}, first: 1000) {
     id
     address
     name

--- a/packages/gql/src/balancer/pools.ts
+++ b/packages/gql/src/balancer/pools.ts
@@ -31,6 +31,8 @@ export const poolWherePoolTypeInAndId = gql`
   ) {
     pools(
       where: { poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0 }
+      orderBy: totalLiquidity
+      orderDirection: desc
     ) {
       id
       address
@@ -60,6 +62,8 @@ export const poolWherePoolType = gql`
   ) {
     pools(
       where: { poolType_in: $poolTypes, totalLiquidity_gt: 0 }
+      orderBy: totalLiquidity
+      orderDirection: desc
       first: 1000
     ) {
       id

--- a/packages/gql/src/balancer/pools.ts
+++ b/packages/gql/src/balancer/pools.ts
@@ -29,11 +29,16 @@ export const poolWherePoolTypeInAndId = gql`
       "GyroE"
     ]
   ) {
-    pools(where: { poolType_in: $poolTypes, id: $poolId }) {
+    pools(where: { poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0 }) {
       id
       address
       name
       poolType
+      symbol
+      totalLiquidity
+      tokens {
+        symbol
+      }
     }
   }
 `;
@@ -51,7 +56,7 @@ export const poolWherePoolType = gql`
       "GyroE"
     ]
   ) {
-    pools(where: { poolType_in: $poolTypes }) {
+    pools(where: { poolType_in: $poolTypes, totalLiquidity_gt: 0 }, first: 1000) {
       id
       address
       name

--- a/packages/gql/src/balancer/pools.ts
+++ b/packages/gql/src/balancer/pools.ts
@@ -29,7 +29,9 @@ export const poolWherePoolTypeInAndId = gql`
       "GyroE"
     ]
   ) {
-    pools(where: { poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0 }) {
+    pools(
+      where: { poolType_in: $poolTypes, id: $poolId, totalLiquidity_gt: 0 }
+    ) {
       id
       address
       name
@@ -56,7 +58,10 @@ export const poolWherePoolType = gql`
       "GyroE"
     ]
   ) {
-    pools(where: { poolType_in: $poolTypes, totalLiquidity_gt: 0 }, first: 1000) {
+    pools(
+      where: { poolType_in: $poolTypes, totalLiquidity_gt: 0 }
+      first: 1000
+    ) {
       id
       address
       name

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   ipfs-http-client: ^60
 
@@ -133,7 +137,7 @@ importers:
         specifier: ^4.6.2
         version: 4.6.2
       next:
-        specifier: ^13.4.13
+        specifier: ^13.3.4
         version: 13.4.13(@babel/core@7.22.9)(react-dom@18.2.0)(react@18.2.0)
       plotly.js:
         specifier: ^2.24.3
@@ -303,19 +307,19 @@ importers:
         version: 13.4.10
       '@typescript-eslint/eslint-plugin':
         specifier: latest
-        version: 6.3.0(@typescript-eslint/parser@6.2.1)(eslint@8.45.0)(typescript@5.1.6)
+        version: 6.2.1(@typescript-eslint/parser@6.2.1)(eslint@8.45.0)(typescript@5.1.6)
       eslint:
         specifier: ^8.45.0
         version: 8.45.0
       eslint-config-next:
         specifier: latest
-        version: 13.4.12(eslint@8.45.0)(typescript@5.1.6)
+        version: 13.4.13(eslint@8.45.0)(typescript@5.1.6)
       eslint-config-prettier:
         specifier: ^8.8.0
         version: 8.8.0(eslint@8.45.0)
       eslint-import-resolver-typescript:
         specifier: ^3.5.5
-        version: 3.5.5(@typescript-eslint/parser@6.2.1)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
+        version: 3.5.5(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
       eslint-plugin-compat:
         specifier: latest
         version: 4.1.4(eslint@8.45.0)
@@ -3580,8 +3584,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/eslint-plugin-next@13.4.12:
-    resolution: {integrity: sha512-6rhK9CdxEgj/j1qvXIyLTWEaeFv7zOK8yJMulz3Owel0uek0U9MJCGzmKgYxM3aAUBo3gKeywCZKyQnJKto60A==}
+  /@next/eslint-plugin-next@13.4.13:
+    resolution: {integrity: sha512-RpZeXlPxQ9FLeYN84XHDqRN20XxmVNclYCraLYdifRsmibtcWUWdwE/ANp2C8kgesFRsvwfsw6eOkYNl9sLJ3A==}
     dependencies:
       glob: 7.1.7
     dev: true
@@ -5576,8 +5580,8 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.3.0(@typescript-eslint/parser@6.2.1)(eslint@8.45.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-IZYjYZ0ifGSLZbwMqIip/nOamFiWJ9AH+T/GYNZBWkVcyNQOFGtSMoWV7RvY4poYCMZ/4lHzNl796WOSNxmk8A==}
+  /@typescript-eslint/eslint-plugin@6.2.1(@typescript-eslint/parser@6.2.1)(eslint@8.45.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-iZVM/ALid9kO0+I81pnp1xmYiFyqibAHzrqX4q5YvvVEyJqY+e6rfTXSCsc2jUxGNqJqTfFSSij/NFkZBiBzLw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
@@ -5589,10 +5593,10 @@ packages:
     dependencies:
       '@eslint-community/regexpp': 4.6.2
       '@typescript-eslint/parser': 6.2.1(eslint@8.45.0)(typescript@5.1.6)
-      '@typescript-eslint/scope-manager': 6.3.0
-      '@typescript-eslint/type-utils': 6.3.0(eslint@8.45.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.3.0(eslint@8.45.0)(typescript@5.1.6)
-      '@typescript-eslint/visitor-keys': 6.3.0
+      '@typescript-eslint/scope-manager': 6.2.1
+      '@typescript-eslint/type-utils': 6.2.1(eslint@8.45.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.2.1(eslint@8.45.0)(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.2.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.45.0
       graphemer: 1.4.0
@@ -5601,26 +5605,6 @@ packages:
       natural-compare-lite: 1.4.0
       semver: 7.5.4
       ts-api-utils: 1.0.1(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser@5.62.0(eslint@8.45.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.45.0
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -5647,14 +5631,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@5.62.0:
-    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-    dev: true
-
   /@typescript-eslint/scope-manager@6.2.1:
     resolution: {integrity: sha512-UCqBF9WFqv64xNsIEPfBtenbfodPXsJ3nPAr55mGPkQIkiQvgoWNo+astj9ZUfJfVKiYgAZDMnM6dIpsxUMp3Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -5663,16 +5639,8 @@ packages:
       '@typescript-eslint/visitor-keys': 6.2.1
     dev: true
 
-  /@typescript-eslint/scope-manager@6.3.0:
-    resolution: {integrity: sha512-WlNFgBEuGu74ahrXzgefiz/QlVb+qg8KDTpknKwR7hMH+lQygWyx0CQFoUmMn1zDkQjTBBIn75IxtWss77iBIQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    dependencies:
-      '@typescript-eslint/types': 6.3.0
-      '@typescript-eslint/visitor-keys': 6.3.0
-    dev: true
-
-  /@typescript-eslint/type-utils@6.3.0(eslint@8.45.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-7Oj+1ox1T2Yc8PKpBvOKWhoI/4rWFd1j7FA/rPE0lbBPXTKjdbtC+7Ev0SeBjEKkIhKWVeZSP+mR7y1Db1CdfQ==}
+  /@typescript-eslint/type-utils@6.2.1(eslint@8.45.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-fTfCgomBMIgu2Dh2Or3gMYgoNAnQm3RLtRp+jP7A8fY+LJ2+9PNpi5p6QB5C4RSP+U3cjI0vDlI3mspAkpPVbQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -5681,8 +5649,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.3.0(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.3.0(eslint@8.45.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.2.1(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.2.1(eslint@8.45.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.45.0
       ts-api-utils: 1.0.1(typescript@5.1.6)
@@ -5691,40 +5659,9 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@5.62.0:
-    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
   /@typescript-eslint/types@6.2.1:
     resolution: {integrity: sha512-528bGcoelrpw+sETlyM91k51Arl2ajbNT9L4JwoXE2dvRe1yd8Q64E4OL7vHYw31mlnVsf+BeeLyAZUEQtqahQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
-    dev: true
-
-  /@typescript-eslint/types@6.3.0:
-    resolution: {integrity: sha512-K6TZOvfVyc7MO9j60MkRNWyFSf86IbOatTKGrpTQnzarDZPYPVy0oe3myTMq7VjhfsUAbNUW8I5s+2lZvtx1gg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    dev: true
-
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@6.2.1(typescript@5.1.6):
@@ -5748,29 +5685,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.3.0(typescript@5.1.6):
-    resolution: {integrity: sha512-Xh4NVDaC4eYKY4O3QGPuQNp5NxBAlEvNQYOqJquR2MePNxO11E5K3t5x4M4Mx53IZvtpW+mBxIT0s274fLUocg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 6.3.0
-      '@typescript-eslint/visitor-keys': 6.3.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      ts-api-utils: 1.0.1(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/utils@6.3.0(eslint@8.45.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-hLLg3BZE07XHnpzglNBG8P/IXq/ZVXraEbgY7FM0Cnc1ehM8RMdn9mat3LubJ3KBeYXXPxV1nugWbQPjGeJk6Q==}
+  /@typescript-eslint/utils@6.2.1(eslint@8.45.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-eBIXQeupYmxVB6S7x+B9SdBeB6qIdXKjgQBge2J+Ouv8h9Cxm5dHf/gfAZA6dkMaag+03HdbVInuXMmqFB/lKQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -5778,9 +5694,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.45.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 6.3.0
-      '@typescript-eslint/types': 6.3.0
-      '@typescript-eslint/typescript-estree': 6.3.0(typescript@5.1.6)
+      '@typescript-eslint/scope-manager': 6.2.1
+      '@typescript-eslint/types': 6.2.1
+      '@typescript-eslint/typescript-estree': 6.2.1(typescript@5.1.6)
       eslint: 8.45.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -5788,27 +5704,11 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@5.62.0:
-    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      eslint-visitor-keys: 3.4.2
-    dev: true
-
   /@typescript-eslint/visitor-keys@6.2.1:
     resolution: {integrity: sha512-iTN6w3k2JEZ7cyVdZJTVJx2Lv7t6zFA8DCrJEHD2mwfc16AEvvBWVhbFh34XyG2NORCd0viIgQY1+u7kPI0WpA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.2.1
-      eslint-visitor-keys: 3.4.2
-    dev: true
-
-  /@typescript-eslint/visitor-keys@6.3.0:
-    resolution: {integrity: sha512-kEhRRj7HnvaSjux1J9+7dBen15CdWmDnwrpyiHsFX6Qx2iW5LOBUgNefOFeh2PjWPlNwN8TOn6+4eBU3J/gupw==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    dependencies:
-      '@typescript-eslint/types': 6.3.0
       eslint-visitor-keys: 3.4.2
     dev: true
 
@@ -8924,8 +8824,8 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next@13.4.12(eslint@8.45.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-ZF0r5vxKaVazyZH/37Au/XItiG7qUOBw+HaH3PeyXltIMwXorsn6bdrl0Nn9N5v5v9spc+6GM2ryjugbjF6X2g==}
+  /eslint-config-next@13.4.13(eslint@8.45.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-EXAh5h1yG/YTNa5YdskzaSZncBjKjvFe2zclMCi2KXyTsXha22wB6MPs/U7idB6a2qjpBdbZcruQY1TWjfNMZw==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
       typescript: '>=3.3.1'
@@ -8933,13 +8833,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@next/eslint-plugin-next': 13.4.12
+      '@next/eslint-plugin-next': 13.4.13
       '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.2.1(eslint@8.45.0)(typescript@5.1.6)
       eslint: 8.45.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.45.0)
       eslint-plugin-react: 7.32.2(eslint@8.45.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.45.0)
@@ -8968,31 +8868,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0):
-    resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-    dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
-      enhanced-resolve: 5.12.0
-      eslint: 8.45.0
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
-      get-tsconfig: 4.5.0
-      globby: 13.1.3
-      is-core-module: 2.11.0
-      is-glob: 4.0.3
-      synckit: 0.8.5
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.2.1)(eslint-plugin-import@2.27.5)(eslint@8.45.0):
+  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0):
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -9013,36 +8889,6 @@ packages:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0):
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@5.1.6)
-      debug: 3.2.7
-      eslint: 8.45.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
-    transitivePeerDependencies:
       - supports-color
     dev: true
 
@@ -9071,7 +8917,7 @@ packages:
       debug: 3.2.7
       eslint: 8.45.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.2.1)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9110,39 +8956,6 @@ packages:
       - encoding
       - typescript
       - utf-8-validate
-    dev: true
-
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@5.1.6)
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.45.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
-      has: 1.0.3
-      is-core-module: 2.11.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.1
-      semver: 6.3.0
-      tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
     dev: true
 
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0):
@@ -16222,6 +16035,7 @@ packages:
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: false
 
   /tslib@2.0.3:
     resolution: {integrity: sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==}
@@ -16251,16 +16065,6 @@ packages:
       ts-morph: 19.0.0
       typescript: 5.1.6
       yargs: 17.7.2
-    dev: true
-
-  /tsutils@3.21.0(typescript@5.1.6):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.1.6
     dev: true
 
   /tunnel-agent@0.6.0:
@@ -17155,7 +16959,3 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
- refactor filtering logic from PoolSearch component;
- copy voting-gauges from https://github.com/balancer/frontend-v2 (@mendesfabio do you know where they store the script to update these voting gauges?)
- add pool pct votes to pool/${id}/round/${number} page, to be used to compute the pool APR in a certain round
- downgrade Next to 13.3.4 to attempt to make it work on Netlify again 🤡  issue: https://answers.netlify.com/t/server-edge-not-defined-error-on-nextjs-ssr-functions-cause-site-to-return-500-errors/91793