### PR TITLE
[Pool Simulator] Implement FX Math Pt.1

### DIFF
--- a/apps/balancer-tools/src/app/poolsimulator/(components)/AnalysisPage.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/AnalysisPage.tsx
@@ -4,7 +4,6 @@ import { Spinner } from "#/components/Spinner";
 import { Tabs } from "#/components/Tabs";
 import { usePoolSimulator } from "#/contexts/PoolSimulatorContext";
 
-import { PoolTypeEnum } from "../(types)";
 import { DepthCost } from "./DepthCost";
 import { ImpactCurve } from "./ImpactCurve";
 import { SwapCurve } from "./SwapCurve";
@@ -32,15 +31,6 @@ export default function Page() {
 
     setCurrentTabTokenByIndex(tokensSymbol.indexOf(target.innerText));
   }
-
-  if (initialData.poolType === PoolTypeEnum.Fx)
-    return (
-      <div>
-        <h1 className="text-slate12">
-          Analysis page not avaliable to {initialData.poolType}
-        </h1>
-      </div>
-    );
 
   return (
     <>

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Menu.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Menu.tsx
@@ -1,6 +1,5 @@
 import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
 import * as Separator from "@radix-ui/react-separator";
-// import { usePathname, useRouter } from "next/navigation";
 import { ReactElement, useEffect, useState } from "react";
 
 import { Dialog } from "#/components/Dialog";
@@ -36,7 +35,6 @@ export enum PoolSimulatorFormTabs {
 }
 
 function IndexMenu() {
-  // const { push } = useRouter();
   const {
     initialData,
     setInitialData,
@@ -92,13 +90,13 @@ function IndexMenu() {
               }
               defaultValue={initialData}
               onTabChanged={(data) => {
-                if (!customData.poolParams?.swapFee) {
+                if (typeof customData.poolParams?.swapFee === "undefined") {
                   setCustomData(data);
                 }
                 setInitialData(data);
               }}
               onSubmit={(data) => {
-                if (!customData.poolParams?.swapFee) {
+                if (typeof customData.poolParams?.swapFee === "undefined") {
                   setCustomData(data);
                 }
                 setInitialData(data);
@@ -134,7 +132,6 @@ function IndexMenu() {
                 setCustomData(data);
                 setIsGraphLoading(true);
                 setIsAnalysis(true);
-                // push("/poolsimulator/analysis");
               }}
             />
           </div>

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/SwapCurve.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/SwapCurve.tsx
@@ -10,7 +10,18 @@ import { usePoolSimulator } from "#/contexts/PoolSimulatorContext";
 import { formatNumber } from "#/utils/formatNumber";
 
 import { PoolTypeEnum, TokensData } from "../(types)";
-import { calculateCurvePoints, trimTrailingValues } from "../(utils)";
+import {
+  calculateCurvePoints,
+  findTokenBySymbol,
+  trimTrailingValues,
+} from "../(utils)";
+
+const POOL_TYPES_TO_ADD_LIMIT = [
+  PoolTypeEnum.Gyro2,
+  PoolTypeEnum.Gyro3,
+  PoolTypeEnum.GyroE,
+  PoolTypeEnum.Fx,
+];
 
 export function SwapCurve() {
   const {
@@ -145,11 +156,7 @@ export function SwapCurve() {
     ),
   ];
 
-  if (
-    [PoolTypeEnum.Gyro2, PoolTypeEnum.Gyro3, PoolTypeEnum.GyroE].includes(
-      initialData.poolType,
-    )
-  ) {
+  if (POOL_TYPES_TO_ADD_LIMIT.includes(initialData.poolType)) {
     data.push(
       createLimitPointDataObject(
         [
@@ -164,11 +171,7 @@ export function SwapCurve() {
       ),
     );
   }
-  if (
-    [PoolTypeEnum.Gyro2, PoolTypeEnum.Gyro3, PoolTypeEnum.GyroE].includes(
-      customData.poolType,
-    )
-  ) {
+  if (POOL_TYPES_TO_ADD_LIMIT.includes(customData.poolType)) {
     data.push(
       createLimitPointDataObject(
         [

--- a/apps/balancer-tools/src/contexts/PoolSimulatorContext.tsx
+++ b/apps/balancer-tools/src/contexts/PoolSimulatorContext.tsx
@@ -178,12 +178,10 @@ export function PoolSimulatorProvider({ children }: PropsWithChildren) {
   }, []);
 
   useEffect(() => {
-    if (!customData.poolType || !customData.poolParams?.swapFee) return;
     asyncSetAMM(initialData, setInitialAMM);
   }, [initialData]);
 
   useEffect(() => {
-    if (!customData.poolType || !customData.poolParams?.swapFee) return;
     asyncSetAMM(customData, setCustomAMM);
   }, [customData]);
 

--- a/packages/math-poolsimulator/src/fx/fixtures/data.json
+++ b/packages/math-poolsimulator/src/fx/fixtures/data.json
@@ -1,0 +1,43 @@
+{
+  "pool": {
+    "id": "0xad0e5e0778cac28f1ff459602b31351871b5754a0002000000000000000003ce",
+    "address": "0xad0e5e0778cac28f1ff459602b31351871b5754a",
+    "poolType": "FX",
+    "symbol": "BPT",
+    "swapFee": "0",
+    "alpha": "0.8",
+    "beta": "0.42",
+    "lambda": "0.3",
+    "delta": "0.3",
+    "epsilon": "0.0008",
+    "swapEnabled": true,
+    "tokens": [
+      {
+        "address": "USDC",
+        "symbol": "USDC",
+        "balance": "58398.373699",
+        "decimals": 6,
+        "priceRate": "1",
+        "weight": null,
+        "token": {
+          "fxOracleDecimals": 8,
+          "latestFXPrice": "0.999941"
+        }
+      },
+      {
+        "address": "EURS",
+        "symbol": "EURS",
+        "balance": "128879.65",
+        "decimals": 2,
+        "priceRate": "1",
+        "weight": null,
+        "token": {
+          "fxOracleDecimals": 8,
+          "latestFXPrice": "1.09549"
+        }
+      }
+    ],
+    "totalShares": "188755.616586050695064249",
+    "tokensList": ["USDC", "EURS"]
+  }
+}

--- a/packages/math-poolsimulator/src/fx/index.test.ts
+++ b/packages/math-poolsimulator/src/fx/index.test.ts
@@ -1,4 +1,4 @@
-import { bnum, SubgraphPoolBase, SwapTypes } from "@balancer-labs/sor";
+import { bnum, FxMaths, SubgraphPoolBase } from "@balancer-labs/sor";
 import { formatFixed } from "@ethersproject/bignumber";
 import { describe, test } from "@jest/globals";
 
@@ -45,103 +45,41 @@ describe("Tests new Fx math function based on package other functions", () => {
         if (!pool._checkIfInIsOnLimit(poolPairData, amountOldBigNumber)) {
           return;
         }
-        // const spotPriceExpected =
-        //   pool._spotPriceAfterSwapExactTokenInForTokenOut(
-        //     poolPairData,
-        //     amountOldBigNumber
-        //   );
 
-        test(`_twoSpotPricePoints`, () => {
+        const spotPriceExpected = FxMaths.spotPriceBeforeSwap(
+          numberToBigNumber({
+            number: amount,
+            decimals: poolPairData.decimalsOut,
+          }),
+          poolPairData
+        );
+
+        test(`_spotPrice`, () => {
           const amountOut = amm.exactTokenInForTokenOut(
             amount,
             tokenIn,
             tokenOut
           );
-          const amountIn = amm.tokenInForExactTokenOut(
-            amountOut,
-            tokenIn,
-            tokenOut
+
+          poolPairData.balanceIn = poolPairData.balanceIn.add(
+            numberToBigNumber({
+              number: amount,
+              decimals: poolPairData.decimalsIn,
+            })
           );
-          const amountInAfterSwap =
-            amount +
-            Number(
-              formatFixed(poolPairData.balanceIn, poolPairData.decimalsIn)
-            );
-          const amountOutAfterSwap =
-            Number(
-              formatFixed(poolPairData.balanceOut, poolPairData.decimalsOut)
-            ) - amountOut;
-          console.log({
-            amount,
-            amountIn,
-            amountOut,
-            percentage,
-            tokenIn,
-            tokenOut,
-            proporcion:
-              amountInAfterSwap / (amountInAfterSwap + amountOutAfterSwap),
-          });
 
-          verifyApproximateEquality(amount, amountIn);
-          //   const spotPriceExpectedOnTokenOut =
-          //     pool._spotPriceAfterSwapTokenInForExactTokenOut(
-          //       poolPairData,
-          //       amountOutBigNumber
-          //     );
+          poolPairData.balanceOut = poolPairData.balanceOut.sub(
+            numberToBigNumber({
+              number: amountOut,
+              decimals: poolPairData.decimalsOut,
+            })
+          );
 
-          //   console.log({
-          //     spotPriceTokenOut: spotPriceExpectedOnTokenOut.toNumber(),
-          //     spotPriceTokenIn: spotPriceExpected.toNumber(),
-          //     tokenIn,
-          //     tokenOut,
-          //     amount,
-          //   });
-          //   verifyApproximateEquality(
-          //     spotPriceExpectedOnTokenOut.toNumber(),
-          //     spotPriceExpected.toNumber()
-          //   );
+          verifyApproximateEquality(
+            pool._spotPrice(poolPairData).toNumber(),
+            spotPriceExpected.toNumber()
+          );
         });
-
-        // test(`_spotPrice`, () => {
-        //   const amountOut = amm.exactTokenInForTokenOut(
-        //     amount,
-        //     tokenIn,
-        //     tokenOut
-        //   );
-        //   poolPairData.balanceIn = poolPairData.balanceIn.add(
-        //     numberToBigNumber({
-        //       number: amount,
-        //       decimals: poolPairData.decimalsIn,
-        //     })
-        //   );
-
-        //   poolPairData.balanceOut = poolPairData.balanceOut.sub(
-        //     numberToBigNumber({
-        //       number: amountOut,
-        //       decimals: poolPairData.decimalsOut,
-        //     })
-        //   );
-        //   //   console.log({
-        //   //     spotPrice: pool._spotPrice(poolPairData).toNumber(),
-        //   //     spotPriceExpected: spotPriceExpected.toNumber(),
-        //   //     tokenIn,
-        //   //     tokenOut,
-        //   //     percentage,
-        //   //   });
-        //   verifyApproximateEquality(
-        //     pool._spotPrice(poolPairData).toNumber(),
-        //     spotPriceExpected.toNumber()
-        //   );
-        // });
-
-        // test(`_tokenInForExactSpotPriceAfterSwap`, () => {
-        //   const tokenInCalculated = amm.tokenInForExactSpotPriceAfterSwap(
-        //     spotPriceExpected.toNumber(),
-        //     tokenIn,
-        //     tokenOut
-        //   );
-        //   verifyApproximateEquality(tokenInCalculated, amount);
-        // });
       });
     });
   });

--- a/packages/math-poolsimulator/src/fx/index.test.ts
+++ b/packages/math-poolsimulator/src/fx/index.test.ts
@@ -29,7 +29,7 @@ describe("Tests new Fx math function based on package other functions", () => {
             delta: poolData.delta,
             lambda: poolData.lambda,
             epsilon: poolData.epsilon,
-          })
+          }),
         );
 
         const pool = ExtendedFx.fromPool(poolData as SubgraphPoolBase);
@@ -37,7 +37,7 @@ describe("Tests new Fx math function based on package other functions", () => {
 
         const amount =
           Number(
-            formatFixed(poolPairData.balanceOut, poolPairData.decimalsOut)
+            formatFixed(poolPairData.balanceOut, poolPairData.decimalsOut),
           ) *
           (percentage / 100);
         const amountOldBigNumber = bnum(amount);
@@ -51,33 +51,33 @@ describe("Tests new Fx math function based on package other functions", () => {
             number: amount,
             decimals: poolPairData.decimalsOut,
           }),
-          poolPairData
+          poolPairData,
         );
 
         test(`_spotPrice`, () => {
           const amountOut = amm.exactTokenInForTokenOut(
             amount,
             tokenIn,
-            tokenOut
+            tokenOut,
           );
 
           poolPairData.balanceIn = poolPairData.balanceIn.add(
             numberToBigNumber({
               number: amount,
               decimals: poolPairData.decimalsIn,
-            })
+            }),
           );
 
           poolPairData.balanceOut = poolPairData.balanceOut.sub(
             numberToBigNumber({
               number: amountOut,
               decimals: poolPairData.decimalsOut,
-            })
+            }),
           );
 
           verifyApproximateEquality(
             pool._spotPrice(poolPairData).toNumber(),
-            spotPriceExpected.toNumber()
+            spotPriceExpected.toNumber(),
           );
         });
       });

--- a/packages/math-poolsimulator/src/fx/index.test.ts
+++ b/packages/math-poolsimulator/src/fx/index.test.ts
@@ -1,0 +1,133 @@
+import { bnum, SubgraphPoolBase } from "@balancer-labs/sor";
+import { formatFixed } from "@ethersproject/bignumber";
+import { describe, test } from "@jest/globals";
+
+import { numberToBigNumber } from "../conversions";
+import { AMM } from "../index";
+import { verifyApproximateEquality } from "../utils";
+import poolsFromFile from "./fixtures/data.json";
+import { ExtendedFx } from "./index";
+
+describe("Tests new Fx math function based on package other functions", () => {
+  const poolData = poolsFromFile["pool"];
+  const tokens = poolData.tokens.map((token) => token.symbol);
+  const percentages = [25, 50, 75, 95];
+
+  tokens.forEach((tokenIn) => {
+    const tokenOut = tokenIn === tokens[0] ? tokens[1] : tokens[0];
+
+    percentages.forEach((percentage) => {
+      describe(`Tests for ${percentage}% with ${tokenIn} as tokenIn`, () => {
+        const amm = new AMM(
+          new ExtendedFx({
+            swapFee: poolData.swapFee,
+            totalShares: poolData.totalShares,
+            tokens: poolData.tokens,
+            tokensList: poolData.tokensList,
+            alpha: poolData.alpha,
+            beta: poolData.beta,
+            delta: poolData.delta,
+            lambda: poolData.lambda,
+            epsilon: poolData.epsilon,
+          })
+        );
+
+        const pool = ExtendedFx.fromPool(poolData as SubgraphPoolBase);
+        const poolPairData = pool.parsePoolPairData(tokenIn, tokenOut);
+
+        const amount =
+          Number(
+            formatFixed(poolPairData.balanceOut, poolPairData.decimalsOut)
+          ) *
+          (percentage / 100);
+        const amountOldBigNumber = bnum(amount);
+        if (!pool._checkIfInIsOnLimit(poolPairData, amountOldBigNumber)) {
+          return;
+        }
+        // const spotPriceExpected =
+        //   pool._spotPriceAfterSwapExactTokenInForTokenOut(
+        //     poolPairData,
+        //     amountOldBigNumber
+        //   );
+
+        test(`_twoSpotPricePoints`, () => {
+          const amountOutBigNumber = pool._exactTokenInForTokenOut(
+            poolPairData,
+            amountOldBigNumber
+          );
+          const amountInBigNumber = pool._tokenInForExactTokenOut(
+            poolPairData,
+            amountOutBigNumber
+          );
+          console.log({
+            amountInBigNumber: amountInBigNumber.toNumber(),
+            amountOldBigNumber: amountOldBigNumber.toNumber(),
+            amountOutBigNumber: amountOutBigNumber.toNumber(),
+          });
+          verifyApproximateEquality(
+            amountInBigNumber.toNumber(),
+            amountOldBigNumber.toNumber()
+          );
+          //   const spotPriceExpectedOnTokenOut =
+          //     pool._spotPriceAfterSwapTokenInForExactTokenOut(
+          //       poolPairData,
+          //       amountOutBigNumber
+          //     );
+
+          //   console.log({
+          //     spotPriceTokenOut: spotPriceExpectedOnTokenOut.toNumber(),
+          //     spotPriceTokenIn: spotPriceExpected.toNumber(),
+          //     tokenIn,
+          //     tokenOut,
+          //     amount,
+          //   });
+          //   verifyApproximateEquality(
+          //     spotPriceExpectedOnTokenOut.toNumber(),
+          //     spotPriceExpected.toNumber()
+          //   );
+        });
+
+        // test(`_spotPrice`, () => {
+        //   const amountOut = amm.exactTokenInForTokenOut(
+        //     amount,
+        //     tokenIn,
+        //     tokenOut
+        //   );
+        //   poolPairData.balanceIn = poolPairData.balanceIn.add(
+        //     numberToBigNumber({
+        //       number: amount,
+        //       decimals: poolPairData.decimalsIn,
+        //     })
+        //   );
+
+        //   poolPairData.balanceOut = poolPairData.balanceOut.sub(
+        //     numberToBigNumber({
+        //       number: amountOut,
+        //       decimals: poolPairData.decimalsOut,
+        //     })
+        //   );
+        //   //   console.log({
+        //   //     spotPrice: pool._spotPrice(poolPairData).toNumber(),
+        //   //     spotPriceExpected: spotPriceExpected.toNumber(),
+        //   //     tokenIn,
+        //   //     tokenOut,
+        //   //     percentage,
+        //   //   });
+        //   verifyApproximateEquality(
+        //     pool._spotPrice(poolPairData).toNumber(),
+        //     spotPriceExpected.toNumber()
+        //   );
+        // });
+
+        // test(`_tokenInForExactSpotPriceAfterSwap`, () => {
+        //   const tokenInCalculated = amm.tokenInForExactSpotPriceAfterSwap(
+        //     spotPriceExpected.toNumber(),
+        //     tokenIn,
+        //     tokenOut
+        //   );
+        //   verifyApproximateEquality(tokenInCalculated, amount);
+        // });
+      });
+    });
+  });
+});

--- a/packages/math-poolsimulator/src/fx/index.test.ts
+++ b/packages/math-poolsimulator/src/fx/index.test.ts
@@ -1,4 +1,4 @@
-import { bnum, SubgraphPoolBase } from "@balancer-labs/sor";
+import { bnum, SubgraphPoolBase, SwapTypes } from "@balancer-labs/sor";
 import { formatFixed } from "@ethersproject/bignumber";
 import { describe, test } from "@jest/globals";
 
@@ -41,6 +41,7 @@ describe("Tests new Fx math function based on package other functions", () => {
           ) *
           (percentage / 100);
         const amountOldBigNumber = bnum(amount);
+
         if (!pool._checkIfInIsOnLimit(poolPairData, amountOldBigNumber)) {
           return;
         }
@@ -51,23 +52,37 @@ describe("Tests new Fx math function based on package other functions", () => {
         //   );
 
         test(`_twoSpotPricePoints`, () => {
-          const amountOutBigNumber = pool._exactTokenInForTokenOut(
-            poolPairData,
-            amountOldBigNumber
+          const amountOut = amm.exactTokenInForTokenOut(
+            amount,
+            tokenIn,
+            tokenOut
           );
-          const amountInBigNumber = pool._tokenInForExactTokenOut(
-            poolPairData,
-            amountOutBigNumber
+          const amountIn = amm.tokenInForExactTokenOut(
+            amountOut,
+            tokenIn,
+            tokenOut
           );
+          const amountInAfterSwap =
+            amount +
+            Number(
+              formatFixed(poolPairData.balanceIn, poolPairData.decimalsIn)
+            );
+          const amountOutAfterSwap =
+            Number(
+              formatFixed(poolPairData.balanceOut, poolPairData.decimalsOut)
+            ) - amountOut;
           console.log({
-            amountInBigNumber: amountInBigNumber.toNumber(),
-            amountOldBigNumber: amountOldBigNumber.toNumber(),
-            amountOutBigNumber: amountOutBigNumber.toNumber(),
+            amount,
+            amountIn,
+            amountOut,
+            percentage,
+            tokenIn,
+            tokenOut,
+            proporcion:
+              amountInAfterSwap / (amountInAfterSwap + amountOutAfterSwap),
           });
-          verifyApproximateEquality(
-            amountInBigNumber.toNumber(),
-            amountOldBigNumber.toNumber()
-          );
+
+          verifyApproximateEquality(amount, amountIn);
           //   const spotPriceExpectedOnTokenOut =
           //     pool._spotPriceAfterSwapTokenInForExactTokenOut(
           //       poolPairData,

--- a/packages/math-poolsimulator/src/fx/index.ts
+++ b/packages/math-poolsimulator/src/fx/index.ts
@@ -1,0 +1,162 @@
+import {
+  bnum,
+  FxMaths,
+  FxPool,
+  OldBigNumber,
+  safeParseFixed,
+  SubgraphPoolBase,
+  SubgraphToken,
+  SwapTypes,
+} from "@balancer-labs/sor";
+import { parseFixed } from "@ethersproject/bignumber";
+
+import { bigNumberToOldBigNumber } from "../conversions";
+import { IAMMFunctionality } from "../types";
+
+type FxPoolToken = Pick<
+  SubgraphToken,
+  "address" | "balance" | "decimals" | "token"
+>;
+
+export type FxPoolPairData = ReturnType<
+  typeof FxPool.prototype.parsePoolPairData
+>;
+
+export interface IFxMaths {
+  swapFee: string;
+  totalShares: string;
+  tokens: FxPoolToken[];
+  tokensList: string[];
+  alpha: string;
+  beta: string;
+  lambda: string;
+  delta: string;
+  epsilon: string;
+}
+
+export class ExtendedFx
+  extends FxPool
+  implements IAMMFunctionality<FxPoolPairData>
+{
+  constructor(poolParams: IFxMaths) {
+    super(
+      "0x",
+      "0x",
+      poolParams.swapFee,
+      poolParams.totalShares,
+      poolParams.tokens,
+      poolParams.tokensList,
+      poolParams.alpha,
+      poolParams.beta,
+      poolParams.lambda,
+      poolParams.delta,
+      poolParams.epsilon
+    );
+  }
+
+  static fromPool(pool: SubgraphPoolBase): ExtendedFx {
+    if (
+      !pool.alpha ||
+      !pool.beta ||
+      !pool.lambda ||
+      !pool.delta ||
+      !pool.epsilon
+    )
+      throw new Error("FX Pool Missing Subgraph Field");
+    return new ExtendedFx({
+      swapFee: pool.swapFee,
+      totalShares: pool.totalShares,
+      tokens: pool.tokens,
+      tokensList: pool.tokensList,
+      alpha: pool.alpha,
+      beta: pool.beta,
+      lambda: pool.lambda,
+      delta: pool.delta,
+      epsilon: pool.epsilon,
+    });
+  }
+
+  parsePoolPairData(tokenIn: string, tokenOut: string): FxPoolPairData {
+    const tokenIndexIn = this.tokens.findIndex((t) => t.address === tokenIn);
+    if (tokenIndexIn < 0) throw "Pool does not contain tokenIn";
+    const tI = this.tokens[tokenIndexIn];
+    const balanceIn = tI.balance;
+    const decimalsIn = tI.decimals;
+
+    const tokenIndexOut = this.tokens.findIndex((t) => t.address === tokenOut);
+
+    if (tokenIndexOut < 0) throw "Pool does not contain tokenOut";
+    const tO = this.tokens[tokenIndexOut];
+    const balanceOut = tO.balance;
+    const decimalsOut = tO.decimals;
+
+    if (!tO.token?.latestFXPrice || !tI.token?.latestFXPrice)
+      throw "FX Pool Missing LatestFxPrice";
+
+    if (tO.token?.fxOracleDecimals == null) {
+      tO.token.fxOracleDecimals = 8;
+    }
+    if (tI.token?.fxOracleDecimals == null) {
+      tI.token.fxOracleDecimals = 8;
+    }
+
+    const poolPairData: FxPoolPairData = {
+      id: this.id,
+      address: this.address,
+      poolType: this.poolType,
+      tokenIn: tokenIn,
+      tokenOut: tokenOut,
+      decimalsIn: Number(decimalsIn),
+      decimalsOut: Number(decimalsOut),
+      balanceIn: parseFixed(balanceIn, decimalsIn),
+      balanceOut: parseFixed(balanceOut, decimalsOut),
+      swapFee: this.swapFee,
+      alpha: this.alpha,
+      beta: this.beta,
+      lambda: this.lambda,
+      delta: this.delta,
+      epsilon: this.epsilon,
+      tokenInLatestFXPrice: parseFixed(
+        tI.token.latestFXPrice,
+        tI.token.fxOracleDecimals
+      ), // decimals is formatted from subgraph in rate we get from the chainlink oracle
+      tokenOutLatestFXPrice: parseFixed(
+        tO.token.latestFXPrice,
+        tO.token.fxOracleDecimals
+      ), // decimals is formatted from subgraph in rate we get from the chainlink oracle
+      tokenInfxOracleDecimals: tI.token.fxOracleDecimals,
+      tokenOutfxOracleDecimals: tO.token.fxOracleDecimals,
+    };
+
+    return poolPairData;
+  }
+
+  _spotPrice(poolPairData: FxPoolPairData): OldBigNumber {
+    return this._inHigherPrecision(
+      FxMaths.spotPriceBeforeSwap,
+      safeParseFixed(bnum(0).toString(), 36),
+      poolPairData
+    );
+  }
+
+  _firstGuessOfTokenInForExactSpotPriceAfterSwap(
+    poolPairData: FxPoolPairData
+  ): OldBigNumber {
+    return bigNumberToOldBigNumber(
+      poolPairData.balanceIn,
+      poolPairData.decimalsIn
+    ).times(bnum(0.01));
+  }
+
+  _checkIfInIsOnLimit(
+    poolPairData: FxPoolPairData,
+    amountIn: OldBigNumber
+  ): boolean {
+    const limitSwap = this.getLimitAmountSwap(
+      poolPairData,
+      SwapTypes.SwapExactIn
+    );
+    console.log(limitSwap, amountIn.toString());
+    return amountIn.lt(limitSwap);
+  }
+}

--- a/packages/math-poolsimulator/src/fx/index.ts
+++ b/packages/math-poolsimulator/src/fx/index.ts
@@ -6,7 +6,6 @@ import {
   safeParseFixed,
   SubgraphPoolBase,
   SubgraphToken,
-  SwapTypes,
 } from "@balancer-labs/sor";
 import { parseFixed } from "@ethersproject/bignumber";
 
@@ -152,11 +151,7 @@ export class ExtendedFx
     poolPairData: FxPoolPairData,
     amountIn: OldBigNumber
   ): boolean {
-    const limitSwap = this.getLimitAmountSwap(
-      poolPairData,
-      SwapTypes.SwapExactIn
-    );
-    console.log(limitSwap, amountIn.toString());
-    return amountIn.lt(limitSwap);
+    const amountOut = this._exactTokenInForTokenOut(poolPairData, amountIn);
+    return amountOut.toNumber() > 0 && amountIn.toNumber() > 0;
   }
 }

--- a/packages/math-poolsimulator/src/fx/index.ts
+++ b/packages/math-poolsimulator/src/fx/index.ts
@@ -49,7 +49,7 @@ export class ExtendedFx
       poolParams.beta,
       poolParams.lambda,
       poolParams.delta,
-      poolParams.epsilon
+      poolParams.epsilon,
     );
   }
 
@@ -117,11 +117,11 @@ export class ExtendedFx
       epsilon: this.epsilon,
       tokenInLatestFXPrice: parseFixed(
         tI.token.latestFXPrice,
-        tI.token.fxOracleDecimals
+        tI.token.fxOracleDecimals,
       ), // decimals is formatted from subgraph in rate we get from the chainlink oracle
       tokenOutLatestFXPrice: parseFixed(
         tO.token.latestFXPrice,
-        tO.token.fxOracleDecimals
+        tO.token.fxOracleDecimals,
       ), // decimals is formatted from subgraph in rate we get from the chainlink oracle
       tokenInfxOracleDecimals: tI.token.fxOracleDecimals,
       tokenOutfxOracleDecimals: tO.token.fxOracleDecimals,
@@ -134,22 +134,22 @@ export class ExtendedFx
     return this._inHigherPrecision(
       FxMaths.spotPriceBeforeSwap,
       safeParseFixed(bnum(0).toString(), 36),
-      poolPairData
+      poolPairData,
     );
   }
 
   _firstGuessOfTokenInForExactSpotPriceAfterSwap(
-    poolPairData: FxPoolPairData
+    poolPairData: FxPoolPairData,
   ): OldBigNumber {
     return bigNumberToOldBigNumber(
       poolPairData.balanceIn,
-      poolPairData.decimalsIn
+      poolPairData.decimalsIn,
     ).times(bnum(0.01));
   }
 
   _checkIfInIsOnLimit(
     poolPairData: FxPoolPairData,
-    amountIn: OldBigNumber
+    amountIn: OldBigNumber,
   ): boolean {
     const amountOut = this._exactTokenInForTokenOut(poolPairData, amountIn);
     return amountOut.toNumber() > 0 && amountIn.toNumber() > 0;

--- a/packages/math-poolsimulator/src/types.ts
+++ b/packages/math-poolsimulator/src/types.ts
@@ -24,26 +24,26 @@ export interface IAMMFunctionality<TPoolPairData extends PoolPairData> {
   parsePoolPairData(tokenIn: string, tokenOut: string): TPoolPairData;
   _exactTokenInForTokenOut(
     poolPairData: TPoolPairData,
-    amountIn: OldBigNumber
+    amountIn: OldBigNumber,
   ): OldBigNumber;
   _tokenInForExactTokenOut(
     poolPairData: TPoolPairData,
-    amountOut: OldBigNumber
+    amountOut: OldBigNumber,
   ): OldBigNumber;
   _spotPrice(poolPairData: TPoolPairData): OldBigNumber;
   _spotPriceAfterSwapExactTokenInForTokenOut(
     poolPairData: TPoolPairData,
-    amountIn: OldBigNumber
+    amountIn: OldBigNumber,
   ): OldBigNumber;
   _derivativeSpotPriceAfterSwapExactTokenInForTokenOut(
     poolPairData: TPoolPairData,
-    amountIn: OldBigNumber
+    amountIn: OldBigNumber,
   ): OldBigNumber;
   _firstGuessOfTokenInForExactSpotPriceAfterSwap(
-    poolPairData: TPoolPairData
+    poolPairData: TPoolPairData,
   ): OldBigNumber;
   _checkIfInIsOnLimit(
     poolPairData: TPoolPairData,
-    amountIn: OldBigNumber
+    amountIn: OldBigNumber,
   ): boolean;
 }

--- a/packages/math-poolsimulator/src/types.ts
+++ b/packages/math-poolsimulator/src/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { OldBigNumber } from "@balancer-labs/sor";
 
+import { FxPoolPairData, IFxMaths } from "./fx";
 import { Gyro2PoolPairData, IGyro2Maths } from "./gyro2";
 import { Gyro3PoolPairData, IGyro3Maths } from "./gyro3";
 import { GyroEPoolPairData, IGyroEMaths } from "./gyroE";
@@ -10,37 +11,39 @@ export type PoolPairData =
   | MetaStablePoolPairData
   | GyroEPoolPairData
   | Gyro2PoolPairData
-  | Gyro3PoolPairData;
+  | Gyro3PoolPairData
+  | FxPoolPairData;
 export type PoolParams =
   | IMetaStableMath
   | IGyroEMaths
   | IGyro2Maths
-  | IGyro3Maths;
+  | IGyro3Maths
+  | IFxMaths;
 
 export interface IAMMFunctionality<TPoolPairData extends PoolPairData> {
   parsePoolPairData(tokenIn: string, tokenOut: string): TPoolPairData;
   _exactTokenInForTokenOut(
     poolPairData: TPoolPairData,
-    amountIn: OldBigNumber,
+    amountIn: OldBigNumber
   ): OldBigNumber;
   _tokenInForExactTokenOut(
     poolPairData: TPoolPairData,
-    amountOut: OldBigNumber,
+    amountOut: OldBigNumber
   ): OldBigNumber;
   _spotPrice(poolPairData: TPoolPairData): OldBigNumber;
   _spotPriceAfterSwapExactTokenInForTokenOut(
     poolPairData: TPoolPairData,
-    amountIn: OldBigNumber,
+    amountIn: OldBigNumber
   ): OldBigNumber;
   _derivativeSpotPriceAfterSwapExactTokenInForTokenOut(
     poolPairData: TPoolPairData,
-    amountIn: OldBigNumber,
+    amountIn: OldBigNumber
   ): OldBigNumber;
   _firstGuessOfTokenInForExactSpotPriceAfterSwap(
-    poolPairData: TPoolPairData,
+    poolPairData: TPoolPairData
   ): OldBigNumber;
   _checkIfInIsOnLimit(
     poolPairData: TPoolPairData,
-    amountIn: OldBigNumber,
+    amountIn: OldBigNumber
   ): boolean;
 }


### PR DESCRIPTION
This PR:
- Add the first version of spot price function for FX pools;
- Enable FX analysis without depth cost chart and with issues on tokens with different prices (e.g. EURS - USDC)
- Fix issue with graph scale on Swap Curve for FX pool.
- Enable 0 of swap fee.