### PR TITLE
[Pool Simulator] Add beta region limit on price impact curve

### DIFF
--- a/apps/balancer-tools/src/__tests__/utils/calculateCurvePoints.test.tsx
+++ b/apps/balancer-tools/src/__tests__/utils/calculateCurvePoints.test.tsx
@@ -4,7 +4,10 @@ describe("calculateCurvePoints", () => {
   it("should return an array of calculated points with a given balance and start", () => {
     const balance = 1000;
     const start = 10;
-    const result = calculateCurvePoints({ balance, start });
+    const result = calculateCurvePoints({
+      balance,
+      startPercentage: start / balance,
+    });
 
     expect(result.length).toBe(121);
 
@@ -21,19 +24,13 @@ describe("calculateCurvePoints", () => {
     expect(result[0]).toBe(0);
   });
 
-  it("should handle negative start value", () => {
-    const balance = 1000;
-    const start = -10;
-    const result = calculateCurvePoints({ balance, start });
-
-    expect(result.length).toBe(121);
-    expect(result[0]).toBe(start);
-  });
-
   it("should generate points that follow the expected curve", () => {
     const balance = 1000;
     const start = 10;
-    const result = calculateCurvePoints({ balance, start });
+    const result = calculateCurvePoints({
+      balance,
+      startPercentage: start / balance,
+    });
     const initialValue = balance * 0.001;
     const stepRatio = Math.pow(balance / initialValue, 1 / 99);
 

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/AnalysisPage.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/AnalysisPage.tsx
@@ -3,9 +3,9 @@
 import { Tabs } from "#/components/Tabs";
 import { usePoolSimulator } from "#/contexts/PoolSimulatorContext";
 
+import { ImpactCurve } from "./Curves/ImpactCurve";
+import { SwapCurve } from "./Curves/SwapCurve";
 import { DepthCost } from "./DepthCost";
-import { ImpactCurve } from "./ImpactCurve";
-import { SwapCurve } from "./SwapCurve";
 import { SwapSimulator } from "./SwapSimulator";
 import { TokensDistribution } from "./TokensDistribution";
 
@@ -14,11 +14,11 @@ export default function Page() {
     usePoolSimulator();
 
   const indexCurrentTabToken = initialData?.tokens.findIndex(
-    ({ symbol }) => symbol.toLowerCase() !== analysisToken.symbol.toLowerCase(),
+    ({ symbol }) => symbol.toLowerCase() !== analysisToken.symbol.toLowerCase()
   );
   const tokensSymbol = initialData.tokens.map((token) => token.symbol);
   const tabTokens = tokensSymbol.filter(
-    (token) => token !== analysisToken.symbol,
+    (token) => token !== analysisToken.symbol
   );
 
   function handleTabClick(event: React.FormEvent<HTMLButtonElement>) {

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/AnalysisPage.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/AnalysisPage.tsx
@@ -14,11 +14,11 @@ export default function Page() {
     usePoolSimulator();
 
   const indexCurrentTabToken = initialData?.tokens.findIndex(
-    ({ symbol }) => symbol.toLowerCase() !== analysisToken.symbol.toLowerCase()
+    ({ symbol }) => symbol.toLowerCase() !== analysisToken.symbol.toLowerCase(),
   );
   const tokensSymbol = initialData.tokens.map((token) => token.symbol);
   const tabTokens = tokensSymbol.filter(
-    (token) => token !== analysisToken.symbol
+    (token) => token !== analysisToken.symbol,
   );
 
   function handleTabClick(event: React.FormEvent<HTMLButtonElement>) {

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/ImpactCurve.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/ImpactCurve.tsx
@@ -32,10 +32,10 @@ interface Amounts {
 const createAndPostWorker = (
   messageData: ImpactWorkerInputData,
   setInitialAmounts: Dispatch<SetStateAction<Amounts>>,
-  setCustomAmounts: Dispatch<SetStateAction<Amounts>>
+  setCustomAmounts: Dispatch<SetStateAction<Amounts>>,
 ) => {
   const worker = new Worker(
-    new URL("../../(workers)/impact-curve-calculation.ts", import.meta.url)
+    new URL("../../(workers)/impact-curve-calculation.ts", import.meta.url),
   );
 
   worker.onmessage = (event: MessageEvent<ImpactWorkerOutputData>) => {
@@ -98,7 +98,7 @@ export function ImpactCurve() {
     ];
 
     messages.forEach((message) =>
-      createAndPostWorker(message, setInitialAmounts, setCustomAmounts)
+      createAndPostWorker(message, setInitialAmounts, setCustomAmounts),
     );
   }, [initialData, customData, analysisToken, currentTabToken]);
 
@@ -107,7 +107,7 @@ export function ImpactCurve() {
     direction: "in" | "out",
     amount: number,
     tokenFrom: string,
-    tokenTo: string
+    tokenTo: string,
   ) => {
     const formattedAmount = formatNumber(amount, 2);
     return direction === "in"
@@ -118,7 +118,7 @@ export function ImpactCurve() {
   const createHoverTemplate = (
     amounts: number[],
     direction: "in" | "out",
-    impactData: number[]
+    impactData: number[],
   ): string[] => {
     return amounts.map((amount, i) => {
       const swapFromSymbol =
@@ -130,7 +130,7 @@ export function ImpactCurve() {
         direction,
         amount,
         swapFromSymbol,
-        swapToSymbol
+        swapToSymbol,
       );
 
       const impact = formatNumber(impactData[i] / 100, 2, "percent");
@@ -146,7 +146,7 @@ export function ImpactCurve() {
     name: string,
     isLegendShown: boolean,
     direction: "in" | "out",
-    lineStyle: "solid" | "dashdot" = "solid"
+    lineStyle: "solid" | "dashdot" = "solid",
   ) => {
     const line =
       lineStyle === "dashdot"
@@ -165,7 +165,7 @@ export function ImpactCurve() {
       hovertemplate: createHoverTemplate(
         hovertemplateData,
         direction,
-        impactData
+        impactData,
       ),
       line,
     };
@@ -174,7 +174,7 @@ export function ImpactCurve() {
   const createLimitPointDataObject = (
     x: number[],
     y: number[],
-    legendGroup: string
+    legendGroup: string,
   ) => {
     return {
       x,
@@ -193,7 +193,7 @@ export function ImpactCurve() {
   const createBetaLimitsDataObject = (
     x: number[],
     y: number[],
-    legendGroup: string
+    legendGroup: string,
   ) => {
     // https://docs.xave.co/product-overview-1/fxpools/amm-faqs
     return {
@@ -226,7 +226,7 @@ export function ImpactCurve() {
       "Initial",
       analysisToken.symbol,
       true,
-      "in"
+      "in",
     ),
     createDataObject(
       customAmounts.analysisTokenIn.amounts,
@@ -234,7 +234,7 @@ export function ImpactCurve() {
       "Custom",
       analysisToken.symbol,
       true,
-      "in"
+      "in",
     ),
     createDataObject(
       initialAmounts.tabTokenIn.amounts,
@@ -243,7 +243,7 @@ export function ImpactCurve() {
       currentTabToken.symbol,
       true,
       "out",
-      "dashdot"
+      "dashdot",
     ),
     createDataObject(
       customAmounts.tabTokenIn.amounts,
@@ -252,7 +252,7 @@ export function ImpactCurve() {
       currentTabToken.symbol,
       true,
       "out",
-      "dashdot"
+      "dashdot",
     ),
   ];
 
@@ -267,8 +267,8 @@ export function ImpactCurve() {
           initialAmounts.analysisTokenIn.priceImpact.slice(-1)[0],
           initialAmounts.tabTokenIn.priceImpact.slice(-1)[0],
         ],
-        "Initial"
-      )
+        "Initial",
+      ),
     );
   }
   if (POOL_TYPES_TO_ADD_LIMIT.includes(customData.poolType)) {
@@ -282,8 +282,8 @@ export function ImpactCurve() {
           customAmounts.analysisTokenIn.priceImpact.slice(-1)[0],
           customAmounts.tabTokenIn.priceImpact.slice(-1)[0],
         ],
-        "Custom"
-      )
+        "Custom",
+      ),
     );
   }
 
@@ -298,11 +298,11 @@ export function ImpactCurve() {
       ];
       const balanceAnalysisToken = findTokenBySymbol(
         pool.tokens,
-        analysisToken.symbol
+        analysisToken.symbol,
       )?.balance;
       const balanceCurrentTabToken = findTokenBySymbol(
         pool.tokens,
-        currentTabToken.symbol
+        currentTabToken.symbol,
       )?.balance;
       const balancesList = [
         { in: balanceAnalysisToken, out: balanceCurrentTabToken },
@@ -327,19 +327,19 @@ export function ImpactCurve() {
         createBetaLimitsDataObject(
           amountLimits,
           priceImpactLimits,
-          legends[index]
-        )
+          legends[index],
+        ),
       );
     }
   });
 
   const maxFromInitialAmounts = Math.max(
     ...initialAmounts.analysisTokenIn.amounts,
-    ...initialAmounts.tabTokenIn.amounts
+    ...initialAmounts.tabTokenIn.amounts,
   );
   const maxFromCustomAmounts = Math.max(
     ...customAmounts.analysisTokenIn.amounts,
-    ...customAmounts.tabTokenIn.amounts
+    ...customAmounts.tabTokenIn.amounts,
   );
   const xlimit = Math.min(maxFromInitialAmounts, maxFromCustomAmounts);
   function indexOfXLimit(value: number, ...arrays: number[][]) {
@@ -362,12 +362,12 @@ export function ImpactCurve() {
   const ylimit = Math.max(
     getImpactOnXLimit(
       initialAmounts.analysisTokenIn.priceImpact,
-      initialAmounts.tabTokenIn.priceImpact
+      initialAmounts.tabTokenIn.priceImpact,
     ),
     getImpactOnXLimit(
       customAmounts.analysisTokenIn.priceImpact,
-      customAmounts.tabTokenIn.priceImpact
-    )
+      customAmounts.tabTokenIn.priceImpact,
+    ),
   );
   return (
     <Plot

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/ImpactCurve.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/ImpactCurve.tsx
@@ -8,30 +8,34 @@ import { Spinner } from "#/components/Spinner";
 import { usePoolSimulator } from "#/contexts/PoolSimulatorContext";
 import { formatNumber } from "#/utils/formatNumber";
 
-import { PoolTypeEnum } from "../(types)";
+import { PoolTypeEnum } from "../../(types)";
+import { findTokenBySymbol, POOL_TYPES_TO_ADD_LIMIT } from "../../(utils)";
 import {
   ImpactWorkerInputData,
   ImpactWorkerOutputData,
-} from "../(workers)/impact-curve-calculation";
+} from "../../(workers)/impact-curve-calculation";
+import { getBetaLimitsIndexes } from "./getBetaLimits";
 
 interface Amounts {
   analysisTokenIn?: {
     amounts: number[];
     priceImpact: number[];
+    amountsOut: number[];
   };
   tabTokenIn?: {
     amounts: number[];
     priceImpact: number[];
+    amountsOut: number[];
   };
 }
 
 const createAndPostWorker = (
   messageData: ImpactWorkerInputData,
   setInitialAmounts: Dispatch<SetStateAction<Amounts>>,
-  setCustomAmounts: Dispatch<SetStateAction<Amounts>>,
+  setCustomAmounts: Dispatch<SetStateAction<Amounts>>
 ) => {
   const worker = new Worker(
-    new URL("../(workers)/impact-curve-calculation.ts", import.meta.url),
+    new URL("../../(workers)/impact-curve-calculation.ts", import.meta.url)
   );
 
   worker.onmessage = (event: MessageEvent<ImpactWorkerOutputData>) => {
@@ -94,7 +98,7 @@ export function ImpactCurve() {
     ];
 
     messages.forEach((message) =>
-      createAndPostWorker(message, setInitialAmounts, setCustomAmounts),
+      createAndPostWorker(message, setInitialAmounts, setCustomAmounts)
     );
   }, [initialData, customData, analysisToken, currentTabToken]);
 
@@ -103,7 +107,7 @@ export function ImpactCurve() {
     direction: "in" | "out",
     amount: number,
     tokenFrom: string,
-    tokenTo: string,
+    tokenTo: string
   ) => {
     const formattedAmount = formatNumber(amount, 2);
     return direction === "in"
@@ -114,7 +118,7 @@ export function ImpactCurve() {
   const createHoverTemplate = (
     amounts: number[],
     direction: "in" | "out",
-    impactData: number[],
+    impactData: number[]
   ): string[] => {
     return amounts.map((amount, i) => {
       const swapFromSymbol =
@@ -126,7 +130,7 @@ export function ImpactCurve() {
         direction,
         amount,
         swapFromSymbol,
-        swapToSymbol,
+        swapToSymbol
       );
 
       const impact = formatNumber(impactData[i] / 100, 2, "percent");
@@ -142,7 +146,7 @@ export function ImpactCurve() {
     name: string,
     isLegendShown: boolean,
     direction: "in" | "out",
-    lineStyle: "solid" | "dashdot" = "solid",
+    lineStyle: "solid" | "dashdot" = "solid"
   ) => {
     const line =
       lineStyle === "dashdot"
@@ -161,7 +165,7 @@ export function ImpactCurve() {
       hovertemplate: createHoverTemplate(
         hovertemplateData,
         direction,
-        impactData,
+        impactData
       ),
       line,
     };
@@ -170,7 +174,7 @@ export function ImpactCurve() {
   const createLimitPointDataObject = (
     x: number[],
     y: number[],
-    legendGroup: string,
+    legendGroup: string
   ) => {
     return {
       x,
@@ -182,6 +186,27 @@ export function ImpactCurve() {
       name: "Liquidity limit",
       showlegend: true,
       hovertemplate: Array(x.length).fill(`Liquidity limit <extra></extra>`),
+      line: { dash: "solid" as const },
+    };
+  };
+
+  const createBetaLimitsDataObject = (
+    x: number[],
+    y: number[],
+    legendGroup: string
+  ) => {
+    // https://docs.xave.co/product-overview-1/fxpools/amm-faqs
+    return {
+      x,
+      y,
+      type: "scatter" as PlotType,
+      mode: "markers" as const,
+      marker: { symbol: "x" as const, size: 10 },
+      legendgroup: legendGroup,
+      legendgrouptitle: { text: legendGroup },
+      name: "Beta region limit",
+      showlegend: true,
+      hovertemplate: Array(x.length).fill(`Beta region <extra></extra>`),
       line: { dash: "solid" as const },
     };
   };
@@ -201,7 +226,7 @@ export function ImpactCurve() {
       "Initial",
       analysisToken.symbol,
       true,
-      "in",
+      "in"
     ),
     createDataObject(
       customAmounts.analysisTokenIn.amounts,
@@ -209,7 +234,7 @@ export function ImpactCurve() {
       "Custom",
       analysisToken.symbol,
       true,
-      "in",
+      "in"
     ),
     createDataObject(
       initialAmounts.tabTokenIn.amounts,
@@ -218,7 +243,7 @@ export function ImpactCurve() {
       currentTabToken.symbol,
       true,
       "out",
-      "dashdot",
+      "dashdot"
     ),
     createDataObject(
       customAmounts.tabTokenIn.amounts,
@@ -227,15 +252,11 @@ export function ImpactCurve() {
       currentTabToken.symbol,
       true,
       "out",
-      "dashdot",
+      "dashdot"
     ),
   ];
 
-  if (
-    [PoolTypeEnum.Gyro2, PoolTypeEnum.Gyro3, PoolTypeEnum.GyroE].includes(
-      initialData.poolType,
-    )
-  ) {
+  if (POOL_TYPES_TO_ADD_LIMIT.includes(initialData.poolType)) {
     data.push(
       createLimitPointDataObject(
         [
@@ -246,15 +267,11 @@ export function ImpactCurve() {
           initialAmounts.analysisTokenIn.priceImpact.slice(-1)[0],
           initialAmounts.tabTokenIn.priceImpact.slice(-1)[0],
         ],
-        "Initial",
-      ),
+        "Initial"
+      )
     );
   }
-  if (
-    [PoolTypeEnum.Gyro2, PoolTypeEnum.Gyro3, PoolTypeEnum.GyroE].includes(
-      customData.poolType,
-    )
-  ) {
+  if (POOL_TYPES_TO_ADD_LIMIT.includes(customData.poolType)) {
     data.push(
       createLimitPointDataObject(
         [
@@ -265,18 +282,64 @@ export function ImpactCurve() {
           customAmounts.analysisTokenIn.priceImpact.slice(-1)[0],
           customAmounts.tabTokenIn.priceImpact.slice(-1)[0],
         ],
-        "Custom",
-      ),
+        "Custom"
+      )
     );
   }
 
+  const poolData = [initialData, customData];
+  const amounts = [initialAmounts, customAmounts];
+  const legends = ["Initial", "Custom"];
+  poolData.forEach((pool, index) => {
+    if (pool.poolType == PoolTypeEnum.Fx && pool.poolParams?.beta) {
+      const amountsList = [
+        amounts[index].analysisTokenIn,
+        amounts[index].tabTokenIn,
+      ];
+      const balanceAnalysisToken = findTokenBySymbol(
+        pool.tokens,
+        analysisToken.symbol
+      )?.balance;
+      const balanceCurrentTabToken = findTokenBySymbol(
+        pool.tokens,
+        currentTabToken.symbol
+      )?.balance;
+      const balancesList = [
+        { in: balanceAnalysisToken, out: balanceCurrentTabToken },
+        { in: balanceCurrentTabToken, out: balanceAnalysisToken },
+      ];
+      const amountLimits = [] as number[];
+      const priceImpactLimits = [] as number[];
+      amountsList.forEach((amount, index) => {
+        const betaLimitsIndexes = getBetaLimitsIndexes({
+          amountsA: amount?.amounts || [],
+          amountsB: amount?.amountsOut || [],
+          initialBalanceA: balancesList[index].in || 0,
+          initialBalanceB: balancesList[index].out || 0,
+          beta: pool.poolParams?.beta || 0,
+        });
+        betaLimitsIndexes.forEach((i) => {
+          amountLimits.push(amount?.amounts[i] || 0);
+          priceImpactLimits.push(amount?.priceImpact[i] || 0);
+        });
+      });
+      data.push(
+        createBetaLimitsDataObject(
+          amountLimits,
+          priceImpactLimits,
+          legends[index]
+        )
+      );
+    }
+  });
+
   const maxFromInitialAmounts = Math.max(
     ...initialAmounts.analysisTokenIn.amounts,
-    ...initialAmounts.tabTokenIn.amounts,
+    ...initialAmounts.tabTokenIn.amounts
   );
   const maxFromCustomAmounts = Math.max(
     ...customAmounts.analysisTokenIn.amounts,
-    ...customAmounts.tabTokenIn.amounts,
+    ...customAmounts.tabTokenIn.amounts
   );
   const xlimit = Math.min(maxFromInitialAmounts, maxFromCustomAmounts);
   function indexOfXLimit(value: number, ...arrays: number[][]) {
@@ -299,12 +362,12 @@ export function ImpactCurve() {
   const ylimit = Math.max(
     getImpactOnXLimit(
       initialAmounts.analysisTokenIn.priceImpact,
-      initialAmounts.tabTokenIn.priceImpact,
+      initialAmounts.tabTokenIn.priceImpact
     ),
     getImpactOnXLimit(
       customAmounts.analysisTokenIn.priceImpact,
-      customAmounts.tabTokenIn.priceImpact,
-    ),
+      customAmounts.tabTokenIn.priceImpact
+    )
   );
   return (
     <Plot

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/ImpactCurve.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/ImpactCurve.tsx
@@ -195,7 +195,6 @@ export function ImpactCurve() {
     y: number[],
     legendGroup: string,
   ) => {
-    // https://docs.xave.co/product-overview-1/fxpools/amm-faqs
     return {
       x,
       y,

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/SwapCurve.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/SwapCurve.tsx
@@ -26,10 +26,10 @@ interface AmountsData {
 const createAndPostSwapWorker = (
   messageData: SwapCurveWorkerInputData,
   setInitialAmounts: Dispatch<SetStateAction<AmountsData>>,
-  setCustomAmounts: Dispatch<SetStateAction<AmountsData>>
+  setCustomAmounts: Dispatch<SetStateAction<AmountsData>>,
 ) => {
   const worker = new Worker(
-    new URL("../../(workers)/swap-curve-calculation.ts", import.meta.url)
+    new URL("../../(workers)/swap-curve-calculation.ts", import.meta.url),
   );
 
   worker.onmessage = (event: MessageEvent<SwapCurveWorkerOutputData>) => {
@@ -53,10 +53,10 @@ export function SwapCurve() {
   if (!initialData || !customData) return <Spinner />;
 
   const [initialAmounts, setInitialAmounts] = useState<AmountsData>(
-    {} as AmountsData
+    {} as AmountsData,
   );
   const [customAmounts, setCustomAmounts] = useState<AmountsData>(
-    {} as AmountsData
+    {} as AmountsData,
   );
 
   useEffect(() => {
@@ -76,7 +76,7 @@ export function SwapCurve() {
     ];
 
     messages.forEach((message) =>
-      createAndPostSwapWorker(message, setInitialAmounts, setCustomAmounts)
+      createAndPostSwapWorker(message, setInitialAmounts, setCustomAmounts),
     );
   }, [initialData, customData, analysisToken, currentTabToken]);
 
@@ -84,7 +84,7 @@ export function SwapCurve() {
     amountIn: number,
     tokenIn: string,
     amountOut: number,
-    tokenOut: string
+    tokenOut: string,
   ) => {
     const formattedAmountIn = formatNumber(amountIn, 2);
     const formattedAmountOut = formatNumber(amountOut, 2);
@@ -96,7 +96,7 @@ export function SwapCurve() {
     y: number[],
     legendGroup: string,
     showlegend = true,
-    hovertemplate: string[]
+    hovertemplate: string[],
   ) => {
     return {
       x,
@@ -113,7 +113,7 @@ export function SwapCurve() {
   const createLimitPointDataObject = (
     x: number[],
     y: number[],
-    legendGroup: string
+    legendGroup: string,
   ) => {
     return {
       x,
@@ -132,7 +132,7 @@ export function SwapCurve() {
     // https://docs.xave.co/product-overview-1/fxpools/amm-faqs
     x_points: number[],
     y_points: number[],
-    legendGroup: string
+    legendGroup: string,
   ) => {
     const x = [x_points[0], x_points[1], x_points[1], x_points[0], x_points[0]];
     const y = [y_points[0], y_points[0], y_points[1], y_points[1], y_points[0]];
@@ -173,9 +173,9 @@ export function SwapCurve() {
           amount,
           analysisToken.symbol,
           -initialAmounts.tabTokenOut[index],
-          currentTabToken.symbol
-        )
-      )
+          currentTabToken.symbol,
+        ),
+      ),
     ),
     createDataObject(
       customAmounts.analysisTokenIn,
@@ -187,9 +187,9 @@ export function SwapCurve() {
           amount,
           analysisToken.symbol,
           -customAmounts.tabTokenOut[index],
-          currentTabToken.symbol
-        )
-      )
+          currentTabToken.symbol,
+        ),
+      ),
     ),
     createDataObject(
       initialAmounts.analysisTokenOut,
@@ -201,9 +201,9 @@ export function SwapCurve() {
           initialAmounts.tabTokenIn[index],
           currentTabToken.symbol,
           -amount,
-          analysisToken.symbol
-        )
-      )
+          analysisToken.symbol,
+        ),
+      ),
     ),
     createDataObject(
       customAmounts.analysisTokenOut,
@@ -215,9 +215,9 @@ export function SwapCurve() {
           customAmounts.tabTokenIn[index],
           currentTabToken.symbol,
           -amount,
-          analysisToken.symbol
-        )
-      )
+          analysisToken.symbol,
+        ),
+      ),
     ),
   ];
 
@@ -232,8 +232,8 @@ export function SwapCurve() {
           initialAmounts.tabTokenIn.slice(-1)[0],
           initialAmounts.tabTokenOut.slice(-1)[0],
         ],
-        "Initial"
-      )
+        "Initial",
+      ),
     );
   }
   if (POOL_TYPES_TO_ADD_LIMIT.includes(customData.poolType)) {
@@ -247,8 +247,8 @@ export function SwapCurve() {
           customAmounts.tabTokenIn.slice(-1)[0],
           customAmounts.tabTokenOut.slice(-1)[0],
         ],
-        "Custom"
-      )
+        "Custom",
+      ),
     );
   }
   const poolData = [initialData, customData];
@@ -259,7 +259,7 @@ export function SwapCurve() {
     if (pool.poolType == PoolTypeEnum.Fx && pool.poolParams?.beta) {
       const analysisBalance = findTokenBySymbol(
         pool.tokens,
-        analysisToken.symbol
+        analysisToken.symbol,
       )?.balance;
       const tabBalance = findTokenBySymbol(pool.tokens, currentTabToken.symbol)
         ?.balance;
@@ -270,7 +270,11 @@ export function SwapCurve() {
         beta: pool.poolParams.beta,
       });
       data.push(
-        createBetaRegionDataObject(betaLimits[0], betaLimits[1], legends[index])
+        createBetaRegionDataObject(
+          betaLimits[0],
+          betaLimits[1],
+          legends[index],
+        ),
       );
     }
   });
@@ -284,19 +288,19 @@ export function SwapCurve() {
   }) {
     const initialAxisToken = findTokenBySymbol(
       initialData.tokens,
-      axisBalanceSymbol
+      axisBalanceSymbol,
     );
     const customAxisToken = findTokenBySymbol(
       customData.tokens,
-      axisBalanceSymbol
+      axisBalanceSymbol,
     );
     const initialOppositeAxisToken = findTokenBySymbol(
       initialData.tokens,
-      oppositeAxisBalanceSymbol
+      oppositeAxisBalanceSymbol,
     );
     const customOppositeAxisToken = findTokenBySymbol(
       customData.tokens,
-      oppositeAxisBalanceSymbol
+      oppositeAxisBalanceSymbol,
     );
     const axisBalances = [
       initialAxisToken?.balance || 0,
@@ -306,7 +310,7 @@ export function SwapCurve() {
     const convertBalanceScale = (
       balance?: number,
       balanceRate?: number,
-      newRate?: number
+      newRate?: number,
     ) => {
       if (!balance || !balanceRate || !newRate) return 0;
       return (balance * balanceRate) / newRate;
@@ -316,12 +320,12 @@ export function SwapCurve() {
       convertBalanceScale(
         initialOppositeAxisToken?.balance,
         initialOppositeAxisToken?.rate,
-        initialAxisToken?.rate
+        initialAxisToken?.rate,
       ),
       convertBalanceScale(
         customOppositeAxisToken?.balance,
         customOppositeAxisToken?.rate,
-        customAxisToken?.rate
+        customAxisToken?.rate,
       ),
     ];
 

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/SwapCurve.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/SwapCurve.tsx
@@ -129,7 +129,6 @@ export function SwapCurve() {
   };
 
   const createBetaRegionDataObject = (
-    // https://docs.xave.co/product-overview-1/fxpools/amm-faqs
     x_points: number[],
     y_points: number[],
     legendGroup: string,

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.test.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.test.ts
@@ -19,13 +19,13 @@ describe("Token Functions", () => {
   describe("getTransitionIndices", () => {
     test("Should return indices of continuous true values", () => {
       expect(
-        getTransitionIndices([false, false, true, true, true, false])
+        getTransitionIndices([false, false, true, true, true, false]),
       ).toEqual([2, 4]);
     });
 
     test("Should throw an error for non-continuous true values", () => {
       expect(() =>
-        getTransitionIndices([false, false, true, false, true, true])
+        getTransitionIndices([false, false, true, false, true, true]),
       ).toThrow("The true values are not continuous.");
     });
 

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.test.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.test.ts
@@ -1,14 +1,14 @@
-import getBetaLimitIndexes, {
+import getBetaLimits, {
   computeSwapAmounts,
   findTransitions,
   getTransitionIndices,
   isInBetaRegion,
-} from "./getBetaLimitIndexes";
+} from "./getBetaLimits";
 
 describe("Token Functions", () => {
   test("computeSwapAmounts", () => {
-    const result = computeSwapAmounts([10, 20], [30, 40], 5);
-    expect(result).toEqual([25, 15, 35, 45]);
+    const result = computeSwapAmounts([-5, -10], [10, 20]);
+    expect(result).toEqual([-10, -5, 10, 20]);
   });
 
   test("isInBetaRegion", () => {
@@ -19,13 +19,13 @@ describe("Token Functions", () => {
   describe("getTransitionIndices", () => {
     test("Should return indices of continuous true values", () => {
       expect(
-        getTransitionIndices([false, false, true, true, true, false]),
+        getTransitionIndices([false, false, true, true, true, false])
       ).toEqual([2, 4]);
     });
 
     test("Should throw an error for non-continuous true values", () => {
       expect(() =>
-        getTransitionIndices([false, false, true, false, true, true]),
+        getTransitionIndices([false, false, true, false, true, true])
       ).toThrow("The true values are not continuous.");
     });
 
@@ -55,22 +55,22 @@ describe("Token Functions", () => {
     });
   });
 
-  describe("getBetaLimitIndexes", () => {
+  describe("getBetaLimits", () => {
     test("Should return correct swap amounts for beta region", () => {
       const params = {
-        analysisTokenOut: [5, 10, 15],
-        analysisTokenIn: [20, 25, 30],
-        tabTokenIn: [7, 12, 17],
-        tabTokenOut: [22, 27, 32],
-        analysisTokenInitialBalance: 100,
-        tabTokenInitialBalance: 105,
+        analysisTokenOut: [0, -5, -10, -15],
+        analysisTokenIn: [0, 5, 10, 15],
+        tabTokenIn: [0, 5, 10, 15],
+        tabTokenOut: [0, -5, -10, -15],
+        analysisTokenInitialBalance: 120,
+        tabTokenInitialBalance: 120,
         beta: 0.05,
       };
 
-      const result = getBetaLimitIndexes(params);
+      const result = getBetaLimits(params);
       expect(result).toEqual([
-        [115, 130],
-        [122, 137],
+        [-5, 5],
+        [5, -5],
       ]);
     });
   });

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.ts
@@ -10,8 +10,19 @@ export const computeBalances = (swaps: number[], initialBalance: number) =>
 export const isInBetaRegion = (
   balanceX: number,
   balanceY: number,
-  beta: number,
+  beta: number
 ) => Math.abs(balanceX - balanceY) / (balanceX + balanceY) < beta;
+
+export const findTransitions = (
+  analysisAmounts: number[],
+  tabAmounts: number[],
+  beta: number
+) => {
+  const inBetaRegion = analysisAmounts.map((analysisValue, idx) =>
+    isInBetaRegion(analysisValue, tabAmounts[idx], beta)
+  );
+  return getTransitionIndices(inBetaRegion);
+};
 
 export function getTransitionIndices(booleans: boolean[]): number[] {
   const trueIndices = booleans
@@ -30,18 +41,35 @@ export function getTransitionIndices(booleans: boolean[]): number[] {
   return end === start ? [start] : [start, end];
 }
 
-export const findTransitions = (
-  analysisAmounts: number[],
-  tabAmounts: number[],
-  beta: number,
-) => {
-  const inBetaRegion = analysisAmounts.map((analysisValue, idx) =>
-    isInBetaRegion(analysisValue, tabAmounts[idx], beta),
-  );
-  return getTransitionIndices(inBetaRegion);
-};
+export function getBetaLimitsIndexes({
+  amountsA,
+  amountsB,
+  initialBalanceA,
+  initialBalanceB,
+  beta,
+}: {
+  amountsA: number[];
+  amountsB: number[];
+  initialBalanceA: number;
+  initialBalanceB: number;
+  beta: number;
+}) {
+  const balancesA = computeBalances(amountsA, initialBalanceA);
+  const balancesB = computeBalances(amountsB, initialBalanceB);
 
-export default function getBetaLimitIndexes(params: {
+  const [start, end] = findTransitions(balancesA, balancesB, beta);
+  return [start, end].filter((i) => i !== 0);
+}
+
+export default function getBetaLimits({
+  analysisTokenOut,
+  analysisTokenIn,
+  tabTokenIn,
+  tabTokenOut,
+  analysisTokenInitialBalance,
+  tabTokenInitialBalance,
+  beta,
+}: {
   analysisTokenOut: number[];
   analysisTokenIn: number[];
   tabTokenIn: number[];
@@ -50,27 +78,16 @@ export default function getBetaLimitIndexes(params: {
   tabTokenInitialBalance: number;
   beta: number;
 }) {
-  const {
-    analysisTokenOut,
-    analysisTokenIn,
-    tabTokenIn,
-    tabTokenOut,
-    analysisTokenInitialBalance,
-    tabTokenInitialBalance,
-    beta,
-  } = params;
-
   const analysisAmounts = computeSwapAmounts(analysisTokenOut, analysisTokenIn);
   const tabAmounts = computeSwapAmounts(tabTokenIn, tabTokenOut);
 
-  const analysisBalances = computeBalances(
-    analysisAmounts,
-    analysisTokenInitialBalance,
-  );
-  const tabBalances = computeBalances(tabAmounts, tabTokenInitialBalance);
-
-  const [start, end] = findTransitions(analysisBalances, tabBalances, beta);
-
+  const [start, end] = getBetaLimitsIndexes({
+    amountsA: analysisAmounts,
+    amountsB: tabAmounts,
+    initialBalanceA: analysisTokenInitialBalance,
+    initialBalanceB: tabTokenInitialBalance,
+    beta,
+  });
   return [
     [analysisAmounts[start], analysisAmounts[end]],
     [tabAmounts[start], tabAmounts[end]],

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.ts
@@ -10,16 +10,16 @@ export const computeBalances = (swaps: number[], initialBalance: number) =>
 export const isInBetaRegion = (
   balanceX: number,
   balanceY: number,
-  beta: number
+  beta: number,
 ) => Math.abs(balanceX - balanceY) / (balanceX + balanceY) < beta;
 
 export const findTransitions = (
   analysisAmounts: number[],
   tabAmounts: number[],
-  beta: number
+  beta: number,
 ) => {
   const inBetaRegion = analysisAmounts.map((analysisValue, idx) =>
-    isInBetaRegion(analysisValue, tabAmounts[idx], beta)
+    isInBetaRegion(analysisValue, tabAmounts[idx], beta),
   );
   return getTransitionIndices(inBetaRegion);
 };

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/getBetaLimits.ts
@@ -78,6 +78,7 @@ export default function getBetaLimits({
   tabTokenInitialBalance: number;
   beta: number;
 }) {
+  // https://docs.xave.co/product-overview-1/fxpools/amm-faqs
   const analysisAmounts = computeSwapAmounts(analysisTokenOut, analysisTokenIn);
   const tabAmounts = computeSwapAmounts(tabTokenIn, tabTokenOut);
 

--- a/apps/balancer-tools/src/app/poolsimulator/(utils)/index.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(utils)/index.ts
@@ -32,11 +32,11 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
           amp: String(data.poolParams?.ampFactor),
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0),
+            data.tokens.reduce((acc, token) => acc + token.balance, 0)
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
-        }),
+        })
       );
     }
     case PoolTypeEnum.GyroE: {
@@ -45,7 +45,7 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
         new ExtendedGyroEV2({
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0),
+            data.tokens.reduce((acc, token) => acc + token.balance, 0)
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
@@ -59,7 +59,7 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
           },
           derivedGyroEParams: derivedParams,
           tokenRates: data.tokens.map((token) => String(token.rate)),
-        }),
+        })
       );
     }
     case PoolTypeEnum.Gyro2: {
@@ -67,13 +67,13 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
         new ExtendedGyro2({
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0),
+            data.tokens.reduce((acc, token) => acc + token.balance, 0)
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
           sqrtAlpha: String(data.poolParams?.sqrtAlpha),
           sqrtBeta: String(data.poolParams?.sqrtBeta),
-        }),
+        })
       );
     }
     case PoolTypeEnum.Gyro3: {
@@ -81,12 +81,12 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
         new ExtendedGyro3({
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0),
+            data.tokens.reduce((acc, token) => acc + token.balance, 0)
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
           root3Alpha: String(data.poolParams?.root3Alpha),
-        }),
+        })
       );
     }
     case PoolTypeEnum.Fx: {
@@ -94,7 +94,7 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
         new ExtendedFx({
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0),
+            data.tokens.reduce((acc, token) => acc + token.balance, 0)
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
@@ -103,7 +103,7 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
           lambda: String(data.poolParams?.lambda),
           delta: String(data.poolParams?.delta),
           epsilon: String(data.poolParams?.epsilon),
-        }),
+        })
       );
     }
     default:
@@ -208,21 +208,21 @@ export function convertGqlToAnalysisData(poolData: PoolQuery): AnalysisData {
 
 export function calculateCurvePoints({
   balance,
-  start = 0,
+  startPercentage = 0,
 }: {
   balance?: number;
-  start?: number;
+  startPercentage?: number;
 }) {
-  if (!balance || start === undefined) return [];
+  if (!balance || startPercentage === undefined) return [];
   const numberOfPoints = 100;
   const initialValue = balance * 0.001;
   const stepRatio = Math.pow(balance / initialValue, 1 / (numberOfPoints - 1));
 
   return [
-    start,
+    startPercentage * balance,
     ...Array.from(
       { length: numberOfPoints + 20 },
-      (_, index) => initialValue * stepRatio ** index,
+      (_, index) => initialValue * stepRatio ** index
     ),
   ];
 }
@@ -230,7 +230,7 @@ export function calculateCurvePoints({
 export function trimTrailingValues(
   amountsIn: number[],
   amountsOut: number[],
-  valueToTrim: number = 100,
+  valueToTrim: number = 100
 ): { trimmedIn: number[]; trimmedOut: number[] } {
   const lastIndexNonValue = amountsOut
     .slice()
@@ -251,3 +251,10 @@ export function trimTrailingValues(
 export function findTokenBySymbol(tokens: TokensData[], symbol?: string) {
   return tokens.find((token) => token.symbol === symbol);
 }
+
+export const POOL_TYPES_TO_ADD_LIMIT = [
+  PoolTypeEnum.Gyro2,
+  PoolTypeEnum.Gyro3,
+  PoolTypeEnum.GyroE,
+  PoolTypeEnum.Fx,
+];

--- a/apps/balancer-tools/src/app/poolsimulator/(utils)/index.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(utils)/index.ts
@@ -32,11 +32,11 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
           amp: String(data.poolParams?.ampFactor),
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0)
+            data.tokens.reduce((acc, token) => acc + token.balance, 0),
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
-        })
+        }),
       );
     }
     case PoolTypeEnum.GyroE: {
@@ -45,7 +45,7 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
         new ExtendedGyroEV2({
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0)
+            data.tokens.reduce((acc, token) => acc + token.balance, 0),
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
@@ -59,7 +59,7 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
           },
           derivedGyroEParams: derivedParams,
           tokenRates: data.tokens.map((token) => String(token.rate)),
-        })
+        }),
       );
     }
     case PoolTypeEnum.Gyro2: {
@@ -67,13 +67,13 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
         new ExtendedGyro2({
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0)
+            data.tokens.reduce((acc, token) => acc + token.balance, 0),
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
           sqrtAlpha: String(data.poolParams?.sqrtAlpha),
           sqrtBeta: String(data.poolParams?.sqrtBeta),
-        })
+        }),
       );
     }
     case PoolTypeEnum.Gyro3: {
@@ -81,12 +81,12 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
         new ExtendedGyro3({
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0)
+            data.tokens.reduce((acc, token) => acc + token.balance, 0),
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
           root3Alpha: String(data.poolParams?.root3Alpha),
-        })
+        }),
       );
     }
     case PoolTypeEnum.Fx: {
@@ -94,7 +94,7 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
         new ExtendedFx({
           swapFee: String(data.poolParams?.swapFee),
           totalShares: String(
-            data.tokens.reduce((acc, token) => acc + token.balance, 0)
+            data.tokens.reduce((acc, token) => acc + token.balance, 0),
           ),
           tokens: tokensData,
           tokensList: data.tokens.map((token) => String(token.symbol)),
@@ -103,7 +103,7 @@ export async function convertAnalysisDataToAMM(data: AnalysisData) {
           lambda: String(data.poolParams?.lambda),
           delta: String(data.poolParams?.delta),
           epsilon: String(data.poolParams?.epsilon),
-        })
+        }),
       );
     }
     default:
@@ -222,7 +222,7 @@ export function calculateCurvePoints({
     startPercentage * balance,
     ...Array.from(
       { length: numberOfPoints + 20 },
-      (_, index) => initialValue * stepRatio ** index
+      (_, index) => initialValue * stepRatio ** index,
     ),
   ];
 }

--- a/apps/balancer-tools/src/app/poolsimulator/(workers)/impact-curve-calculation.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(workers)/impact-curve-calculation.ts
@@ -71,8 +71,8 @@ self.addEventListener(
           amm.priceImpactForExactTokenInSwap(
             amount,
             swapDirection === "in" ? tokenIn.symbol : tokenOut.symbol,
-            swapDirection === "in" ? tokenOut.symbol : tokenIn.symbol
-          ) * 100
+            swapDirection === "in" ? tokenOut.symbol : tokenIn.symbol,
+          ) * 100,
       );
 
       const { trimmedIn: amounts, trimmedOut: priceImpact } =
@@ -83,8 +83,8 @@ self.addEventListener(
           amm.exactTokenInForTokenOut(
             amount,
             swapDirection === "in" ? tokenIn.symbol : tokenOut.symbol,
-            swapDirection === "in" ? tokenOut.symbol : tokenIn.symbol
-          ) * -1
+            swapDirection === "in" ? tokenOut.symbol : tokenIn.symbol,
+          ) * -1,
       );
 
       return {
@@ -107,5 +107,5 @@ self.addEventListener(
       swapDirection,
     };
     self.postMessage(result);
-  }
+  },
 );

--- a/apps/balancer-tools/src/app/poolsimulator/(workers)/impact-curve-calculation.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(workers)/impact-curve-calculation.ts
@@ -61,11 +61,11 @@ self.addEventListener(
         poolType === PoolTypeEnum.MetaStable
           ? calculateCurvePoints({
               balance: maxBalance,
-              start: 0.001,
+              startPercentage: 0.01,
             })
           : calculateCurvePoints({
               balance: maxBalance,
-              start: 0.001,
+              startPercentage: 0.01,
             }).filter((value) => value <= limitBalance);
 
       const rawPriceImpact = rawAmounts.map(
@@ -73,16 +73,26 @@ self.addEventListener(
           amm.priceImpactForExactTokenInSwap(
             amount,
             swapDirection === "in" ? tokenIn.symbol : tokenOut.symbol,
-            swapDirection === "in" ? tokenOut.symbol : tokenIn.symbol,
-          ) * 100,
+            swapDirection === "in" ? tokenOut.symbol : tokenIn.symbol
+          ) * 100
       );
 
       const { trimmedIn: amounts, trimmedOut: priceImpact } =
         trimTrailingValues(rawAmounts, rawPriceImpact, 100);
 
+      const amountsOut = rawAmounts.map(
+        (amount) =>
+          amm.exactTokenInForTokenOut(
+            amount,
+            swapDirection === "in" ? tokenIn.symbol : tokenOut.symbol,
+            swapDirection === "in" ? tokenOut.symbol : tokenIn.symbol
+          ) * -1
+      );
+
       return {
-        amounts: amounts,
-        priceImpact: priceImpact,
+        amounts,
+        priceImpact,
+        amountsOut,
       };
     };
     const calcResult = calculateTokenImpact({
@@ -99,5 +109,5 @@ self.addEventListener(
       swapDirection,
     };
     self.postMessage(result);
-  },
+  }
 );

--- a/apps/balancer-tools/src/app/poolsimulator/(workers)/impact-curve-calculation.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(workers)/impact-curve-calculation.ts
@@ -59,11 +59,11 @@ self.addEventListener(
         poolType === PoolTypeEnum.MetaStable
           ? calculateCurvePoints({
               balance: maxBalance,
-              startPercentage: 0.01,
+              startPercentage: 0.001,
             })
           : calculateCurvePoints({
               balance: maxBalance,
-              startPercentage: 0.01,
+              startPercentage: 0.001,
             }).filter((value) => value <= limitBalance);
 
       const rawPriceImpact = rawAmounts.map(


### PR DESCRIPTION
This PR:
- Adds the beta region on the price impact curve;
- Refactor Swap curve beta region functions;

<img width="843" alt="image" src="https://github.com/bleu-studio/balancer-tools/assets/55461956/da49fed2-a07e-4594-966f-ad5d89993751">

As shown in the figure above, our beta region limits may not be accurate. This [issue](https://linear.app/bleu-llc/issue/BAL-663/beta-region-limit-calculation) will refer to this.