### PR TITLE
[APR] Refactor API tor return different APR types

### DIFF
--- a/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
@@ -94,12 +94,6 @@ export async function calculatePoolStats({
   ]);
 
   const apr = calculateRoundAPR(round, votingShare, tvl, balPriceUSD);
-  const aprBefore =
-    balPriceUSD && tvl && votingShare
-      ? calculateRoundAPRBefore(round, votingShare, tvl, balPriceUSD) * 100
-      : -1;
-
-  console.log({ apr, aprBefore });
 
   return {
     roundId: Number(roundId),
@@ -131,14 +125,4 @@ function calculateRoundAPR(
       veBAL: vebalAPR,
     },
   };
-}
-
-function calculateRoundAPRBefore(
-  round: Round,
-  votingShare: number,
-  tvl: number,
-  balPriceUSD: number,
-): number {
-  const emissions = balEmissions.weekly(round.endDate.getTime() / 1000);
-  return (WEEKS_IN_YEAR * (emissions * votingShare * balPriceUSD)) / tvl;
 }

--- a/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
@@ -93,10 +93,13 @@ export async function calculatePoolStats({
     ),
   ]);
 
-  const apr =
+  const apr = calculateRoundAPR(round, votingShare, tvl, balPriceUSD);
+  const aprBefore =
     balPriceUSD && tvl && votingShare
-      ? calculateRoundAPR(round, votingShare, tvl, balPriceUSD) * 100
+      ? calculateRoundAPRBefore(round, votingShare, tvl, balPriceUSD) * 100
       : -1;
+
+  console.log({ apr, aprBefore });
 
   return {
     roundId: Number(roundId),
@@ -111,6 +114,26 @@ export async function calculatePoolStats({
 }
 
 function calculateRoundAPR(
+  round: Round,
+  votingShare: number,
+  tvl: number,
+  balPriceUSD: number,
+) {
+  const emissions = balEmissions.weekly(round.endDate.getTime() / 1000);
+  const vebalAPR =
+    balPriceUSD && tvl && votingShare
+      ? ((WEEKS_IN_YEAR * (emissions * votingShare * balPriceUSD)) / tvl) * 100
+      : -1;
+
+  return {
+    total: vebalAPR,
+    breakdown: {
+      veBAL: vebalAPR,
+    },
+  };
+}
+
+function calculateRoundAPRBefore(
   round: Round,
   votingShare: number,
   tvl: number,

--- a/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import * as Sentry from "@sentry/nextjs";
+
 import * as balEmissions from "#/lib/balancer/emissions";
 import { Pool } from "#/lib/balancer/gauges";
 import { pools } from "#/lib/gql/server";
@@ -94,6 +96,13 @@ export async function calculatePoolStats({
   ]);
 
   const apr = calculateRoundAPR(round, votingShare, tvl, balPriceUSD);
+
+  if (apr.total === -1 || apr.breakdown.veBAL === -1) {
+    Sentry.captureMessage("vebalAPR resulted in -1", {
+      level: "warning",
+      extra: { balPriceUSD, tvl, votingShare, roundId, poolId, apr },
+    });
+  }
 
   return {
     roundId: Number(roundId),

--- a/apps/balancer-tools/src/app/apr/api/route.ts
+++ b/apps/balancer-tools/src/app/apr/api/route.ts
@@ -332,13 +332,11 @@ function sortAndLimit(
       let valueA = aValue[sortProperty];
       let valueB = bValue[sortProperty];
 
-      // Special handling for 'apr' as it is an object
       if (sortProperty === "apr") {
         valueA = (valueA as (typeof aValue)["apr"]).total;
         valueB = (valueB as (typeof bValue)["apr"]).total;
       }
 
-      // Handle null, undefined, and NaN values
       if (valueA == null || Number.isNaN(valueA)) return 1;
       if (valueB == null || Number.isNaN(valueB)) return -1;
 

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRChart.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRChart.tsx
@@ -1,4 +1,4 @@
-import { amberDarkA } from "@radix-ui/colors";
+import { amberDarkA, blueDarkA } from "@radix-ui/colors";
 import { PlotType } from "plotly.js";
 
 import { trimTrailingValues } from "#/lib/utils";
@@ -38,7 +38,7 @@ export default async function HistoricalAPRChart({
     0,
   );
 
-  const APRPerRoundData = {
+  const vebalAprPerRoundData = {
     name: "veBAL APR %",
     hovertemplate: HOVERTEMPLATE,
     x: trimmedVebalAprData.trimmedIn,
@@ -47,14 +47,25 @@ export default async function HistoricalAPRChart({
     type: "scatter" as PlotType,
   };
 
-  const chosenRoundMarkerIDX = APRPerRoundData.x.findIndex(
+  const totalAprPerRoundData = {
+    name: "Total APR %",
+    hovertemplate: HOVERTEMPLATE,
+    x: trimmedVebalAprData.trimmedIn,
+    y: trimmedVebalAprData.trimmedOut,
+    line: { shape: "spline", color: blueDarkA.blueA9 } as const,
+    type: "scatter" as PlotType,
+  };
+
+  const aprPerRoundData = [totalAprPerRoundData, vebalAprPerRoundData];
+
+  const chosenRoundMarkerIDX = vebalAprPerRoundData.x.findIndex(
     (item) => item === getRoundName(roundId),
   );
   const chosenRoundData = roundId
     ? {
         hovertemplate: HOVERTEMPLATE,
-        x: [APRPerRoundData.x[chosenRoundMarkerIDX]],
-        y: [APRPerRoundData.y[chosenRoundMarkerIDX]],
+        x: [vebalAprPerRoundData.x[chosenRoundMarkerIDX]],
+        y: [vebalAprPerRoundData.y[chosenRoundMarkerIDX]],
         mode: "markers",
         name: "Selected Round",
         marker: {
@@ -68,5 +79,5 @@ export default async function HistoricalAPRChart({
       }
     : {};
 
-  return <HistoricalAPRPlot data={[APRPerRoundData, chosenRoundData]} />;
+  return <HistoricalAPRPlot data={[...aprPerRoundData, chosenRoundData]} />;
 }

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRChart.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRChart.tsx
@@ -26,7 +26,7 @@ export default async function HistoricalAPRChart({
   const aprPerRoundCords = Object.entries(results.perRound).reduce(
     (cords, [_, result]) => {
       cords.x.push(getRoundName(result.roundId));
-      cords.y.push(result.apr);
+      cords.y.push(result.apr.breakdown.veBAL);
       return cords;
     },
     { x: [], y: [] } as { x: string[]; y: number[] },

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRChart.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRChart.tsx
@@ -32,17 +32,17 @@ export default async function HistoricalAPRChart({
     { x: [], y: [] } as { x: string[]; y: number[] },
   );
 
-  const trimmedAPRData = trimTrailingValues(
+  const trimmedVebalAprData = trimTrailingValues(
     aprPerRoundCords.x.reverse(),
     aprPerRoundCords.y.reverse(),
     0,
   );
 
   const APRPerRoundData = {
-    name: "APR %",
+    name: "veBAL APR %",
     hovertemplate: HOVERTEMPLATE,
-    x: trimmedAPRData.trimmedIn,
-    y: trimmedAPRData.trimmedOut,
+    x: trimmedVebalAprData.trimmedIn,
+    y: trimmedVebalAprData.trimmedOut,
     line: { shape: "spline" } as const,
     type: "scatter" as PlotType,
   };

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRPlot.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRPlot.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { amberDarkA } from "@radix-ui/colors";
-
 import Plot from "#/components/Plot";
 
 export default function HistoricalAPRPlot({ data }: { data: Plotly.Data[] }) {
@@ -18,7 +16,6 @@ export default function HistoricalAPRPlot({ data }: { data: Plotly.Data[] }) {
           yaxis: {
             title: "APR %",
           },
-          colorway: [amberDarkA.amberA11],
         }}
       />
     </div>

--- a/apps/balancer-tools/src/app/apr/pool/(components)/PoolOverviewCards.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/PoolOverviewCards.tsx
@@ -18,7 +18,7 @@ async function AverageAPRCard({ poolId }: { poolId: string }) {
   const data: PoolStatsResults = await fetcher(
     `${process.env.NEXT_PUBLIC_SITE_URL}/apr/api/?poolId=${poolId}`,
   );
-  return <div>{formatAPR(data.average.apr)}</div>;
+  return <div>{formatAPR(data.average.apr.total)}</div>;
 }
 
 export default async function PoolOverviewCards({
@@ -39,7 +39,7 @@ export default async function PoolOverviewCards({
     cardsDetails.push(
       ...[
         { title: "TVL", content: formatTVL(tvl) },
-        { title: "veBAL APR", content: formatAPR(apr) },
+        { title: "veBAL APR", content: formatAPR(apr.breakdown.veBAL) },
         ...getRoundDetails(roundId),
       ],
     );

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
@@ -142,7 +142,7 @@ export function PoolListTable({
                 roundId={roundId}
                 tvl={pool.tvl}
                 votingShare={pool.votingShare}
-                apr={pool.apr}
+                apr={pool.apr.total}
               />
             ))}
             <Table.BodyRow>

--- a/apps/balancer-tools/src/app/apr/round/(components)/TopPoolsChart.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/TopPoolsChart.tsx
@@ -23,7 +23,9 @@ export default async function TopPoolsChart({ roundId }: { roundId: string }) {
     },
     orientation: "h" as const,
     type: "bar" as PlotType,
-    x: topAprApi.perRound.map((result) => result.apr.toFixed(2)),
+    x: topAprApi.perRound.map((result) =>
+      result.apr.breakdown.veBAL.toFixed(2),
+    ),
     y: topAprApi.perRound.map((result) => result.symbol),
   };
 


### PR DESCRIPTION
this PR refactors the API return on APR

previously: 
```
apr: number
```

now: 
```
  apr: {
    total: number;
    breakdown: {
      veBAL: number;
    };
  };
```

- for round views I'm considering APR total, which rn is the same as veBAL APR
