### PR TITLE
[APR] expose collectedFeesUSD to API

### DIFF
--- a/apps/balancer-tools/src/app/apr/api/route.ts
+++ b/apps/balancer-tools/src/app/apr/api/route.ts
@@ -34,9 +34,13 @@ export interface PoolStats {
   balPriceUSD: number;
   tvl: number;
   votingShare: number;
+  collectedFeesUSD: number;
 }
 
-type PoolStatsWithoutVotingShare = Omit<PoolStats, "votingShare">;
+type PoolStatsWithoutVotingShareAndCollectedFees = Omit<
+  PoolStats,
+  "votingShare" | "collectedFeesUSD"
+>;
 
 export interface PoolStatsData extends PoolStats {
   symbol: string;
@@ -49,7 +53,7 @@ export interface PoolStatsData extends PoolStats {
 
 export interface PoolStatsResults {
   perRound: PoolStatsData[];
-  average: PoolStatsWithoutVotingShare;
+  average: PoolStatsWithoutVotingShareAndCollectedFees;
 }
 
 const memoryCache: { [key: string]: unknown } = {};
@@ -71,7 +75,7 @@ const getDataFromCacheOrCompute = async <T>(
 
 const computeAverages = (
   poolData: PoolStatsData[],
-): PoolStatsWithoutVotingShare => {
+): PoolStatsWithoutVotingShareAndCollectedFees => {
   const total = poolData.reduce(
     (acc, data) => ({
       apr: {


### PR DESCRIPTION
This PR just exposes feeDiff as collectedFeesUSD to be shown on future chart on https://linear.app/bleu-llc/issue/BAL-712/add-tabs-with-historical-volume-tvl-collected-fees


Example of possible chart: 
![image](https://github.com/bleu-studio/balancer-tools/assets/63298341/1e8ef9f1-a3fc-441c-be17-162e0080c60d)

