### PR TITLE
[APR] Minor UI fixes

### DIFF
--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRPlot.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalAPRPlot.tsx
@@ -23,6 +23,7 @@ export default function HistoricalAPRPlot({ data }: { data: Plotly.Data[] }) {
           autosize: true,
           xaxis: {
             fixedrange: true,
+            dtick: 1,
             title: "Round Number",
           },
           yaxis: {

--- a/apps/balancer-tools/src/app/apr/pool/(components)/PoolTokens.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/PoolTokens.tsx
@@ -1,3 +1,4 @@
+import { PlotTitle } from "#/components/Plot";
 import { fetcher } from "#/utils/fetcher";
 
 import { BASE_URL, PoolStatsResults } from "../../api/route";
@@ -16,9 +17,12 @@ export default async function PoolTokens({
     }`,
   );
   return (
-    <PoolTokensTable
-      poolTokensStats={poolData.perRound[0].tokens}
-      poolNetwork={poolData.perRound[0].network}
-    />
+    <div>
+      <PlotTitle title="Pool Composition" classNames="py-3" />
+      <PoolTokensTable
+        poolTokensStats={poolData.perRound[0].tokens}
+        poolNetwork={poolData.perRound[0].network}
+        />
+    </div>
   );
 }

--- a/apps/balancer-tools/src/app/apr/pool/(components)/PoolTokens.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/PoolTokens.tsx
@@ -22,7 +22,7 @@ export default async function PoolTokens({
       <PoolTokensTable
         poolTokensStats={poolData.perRound[0].tokens}
         poolNetwork={poolData.perRound[0].network}
-        />
+      />
     </div>
   );
 }

--- a/apps/balancer-tools/src/app/apr/pool/(components)/PoolTokensTable.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/PoolTokensTable.tsx
@@ -14,9 +14,11 @@ export default function PoolTokensTable({
   poolTokensStats: PoolTokens[];
   poolNetwork: string;
 }) {
-  const tokenUrl = `${
-    networkUrls[poolNetwork as unknown as NetworkChainId].url
-  }address/${poolTokensStats[0].address}`;
+  const tokenUrl = (tokenAddress: string) =>
+    `${
+      networkUrls[poolNetwork as unknown as NetworkChainId].url
+    }address/${tokenAddress}`;
+
   const tokenBalanceUSD = (value: number) =>
     value.toLocaleString("en-US", {
       minimumFractionDigits: 0,
@@ -52,7 +54,7 @@ export default function PoolTokensTable({
           {poolTokensStats.map((token) => (
             <Table.BodyRow classNames="hover:bg-blue4 hover:cursor-pointer duration-500">
               <Table.BodyCellLink
-                href={tokenUrl}
+                href={tokenUrl(token.address)}
                 tdClassNames="w-max"
                 linkClassNames="flex gap-2 items-center"
               >
@@ -72,7 +74,7 @@ export default function PoolTokensTable({
               </Table.BodyCellLink>
               {token.weight && (
                 <Table.BodyCellLink
-                  href={tokenUrl}
+                  href={tokenUrl(token.address)}
                   tdClassNames="w-6"
                   linkClassNames="justify-end w-full"
                 >{`${(
@@ -81,7 +83,7 @@ export default function PoolTokensTable({
               )}
               {token.balance && (
                 <Table.BodyCellLink
-                  href={tokenUrl}
+                  href={tokenUrl(token.address)}
                   tdClassNames="w-6"
                   linkClassNames="justify-end w-full"
                 >
@@ -92,7 +94,7 @@ export default function PoolTokensTable({
               )}
               {token.price && token.balance && (
                 <Table.BodyCellLink
-                  href={tokenUrl}
+                  href={tokenUrl(token.address)}
                   tdClassNames="w-6"
                   linkClassNames="justify-end w-full"
                 >
@@ -101,7 +103,7 @@ export default function PoolTokensTable({
               )}
               {token.price && token.balance && (
                 <Table.BodyCellLink
-                  href={tokenUrl}
+                  href={tokenUrl(token.address)}
                   tdClassNames="w-6"
                   linkClassNames="justify-end w-full"
                 >

--- a/apps/balancer-tools/src/app/apr/round/(components)/MoreFiltersButton.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/MoreFiltersButton.tsx
@@ -94,6 +94,11 @@ export function MoreFiltersButton() {
       }
     });
 
+    if (!searchParams.has("sort")) {
+      current.set("sort", "apr");
+      current.set("order", "desc");
+    }
+
     const search = current.toString();
     const query = search ? `?${search}` : "";
     router.push(pathname + query, { scroll: false });

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "#/components";
 import { Badge } from "#/components/Badge";
+import { PlotTitle } from "#/components/Plot";
 import { Spinner } from "#/components/Spinner";
 import Table from "#/components/Table";
 import { Tooltip } from "#/components/Tooltip";
@@ -79,6 +80,11 @@ export function PoolListTable({
 
   return (
     <div className="flex flex-col justify-center text-white">
+      <PlotTitle
+        title={`All Pools`}
+        tooltip="All values are calculated at the end of the round"
+        classNames="py-3"
+      />
       <div className="flex text-white mb-5 gap-2">
         <TokenFilterInput />
         <MoreFiltersButton />
@@ -97,11 +103,6 @@ export function PoolListTable({
                   className="flex gap-x-1 items-center float-right justify-end"
                   href={pathname + "?" + createQueryString("tvl")}
                 >
-                  <Tooltip
-                    content={`This is the TVL calculated at the end of the round`}
-                  >
-                    <InfoCircledIcon />
-                  </Tooltip>
                   <span>TVL</span>
                   {OrderIcon(searchParams, "tvl")}
                 </Link>
@@ -124,9 +125,7 @@ export function PoolListTable({
                   className="flex gap-x-1 items-center float-right justify-end"
                   href={pathname + "?" + createQueryString("apr")}
                 >
-                  <Tooltip
-                    content={`This is the APR calculate at the end of the round`}
-                  >
+                  <Tooltip content={`The value displayed is the min APR`}>
                     <InfoCircledIcon />
                   </Tooltip>
                   <span> APR</span>

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
@@ -27,6 +27,7 @@ import { formatNumber } from "#/utils/formatNumber";
 
 import { PoolTypeEnum } from "../../(utils)/calculatePoolStats";
 import { formatAPR, formatTVL } from "../../(utils)/formatPoolStats";
+import getFilteredRoundApiUrl from "../../(utils)/getFilteredApiUrl";
 import { PoolStatsData, PoolStatsResults, PoolTokens } from "../../api/route";
 import { MoreFiltersButton } from "./MoreFiltersButton";
 import { TokenFilterInput } from "./TokenFilterInput";
@@ -64,14 +65,10 @@ export function PoolListTable({
 
   const loadMorePools = async () => {
     setIsLoadingMore(true);
+    const params = Object.fromEntries(searchParams.entries());
+    params["offset"] = (tableData.length + 1).toString();
     const aditionalPoolsData = await fetcher<PoolStatsResults>(
-      `${
-        process.env.NEXT_PUBLIC_SITE_URL
-      }/apr/api/?roundId=${roundId}&sort=${searchParams.get(
-        "sort",
-      )}&order=${searchParams.get("order")}&limit=10&offset=${
-        Object.keys(tableData).length
-      }&minTvl=1000`,
+      getFilteredRoundApiUrl(params, roundId),
     );
     setTableData((prevTableData) => {
       if (aditionalPoolsData.perRound.length === 0) setHasMorePools(false);

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
@@ -48,6 +48,9 @@ export function PoolListTable({
 
   useEffect(() => {
     setTableData(initialData);
+    if (tableData.length < 10) {
+      setHasMorePools(false);
+    }
   }, [initialData]);
 
   const createQueryString = useCallback(

--- a/apps/balancer-tools/src/app/apr/round/(components)/TopPoolsChart.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/TopPoolsChart.tsx
@@ -79,7 +79,6 @@ export default function TopPoolsChart({
             side: "right",
             // @ts-ignore: 2322
             tickson: "boundaries",
-            tickfont_family: "Arial Black",
           },
         }}
       />

--- a/apps/balancer-tools/src/components/Plot.tsx
+++ b/apps/balancer-tools/src/components/Plot.tsx
@@ -70,16 +70,19 @@ export function PlotTitle({
   title,
   tooltip,
   justifyCenter = true,
+  classNames,
 }: {
   title: string;
   tooltip?: string;
   justifyCenter?: boolean;
+  classNames?: string;
 }) {
   return (
     <div
       className={cn(
         "flex items-center gap-x-2",
         justifyCenter ? "justify-center" : "",
+        classNames,
       )}
     >
       <h2 className="text-lg font-semibold text-white">{title}</h2>


### PR DESCRIPTION
### Changes
 - Added table title
 - Altered table tooltip
 - If table start with <10 pools it will show "All pools have been loaded" instead of "load more"
 - Historical APR now should only show integer
 
### Fixes
 - Redirect with default sorting if not on searchParams
 - Load more not using selected filters
 - Tokens had the same URL


#### Table

Title Tooltip: All values are calculated at the end of the round

APR Tooltip: The value displayed is the min APR

![image](https://github.com/bleu-studio/balancer-tools/assets/68453900/c42cbaca-b963-4c8b-ad78-7e0ed58cf519)
