### PR TITLE
[APR] use avg of vebal price instead of only one point on apr calc

### DIFF
--- a/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
@@ -6,7 +6,7 @@ import { Pool } from "#/lib/balancer/gauges";
 import { pools } from "#/lib/gql/server";
 
 import { PoolStatsData, PoolTokens } from "../api/route";
-import { getBALPriceByRound, getTokenPriceByRound } from "./getBALPriceByRound";
+import { getBALPriceByRound, getTokenPriceByDate } from "./getBALPriceByRound";
 import { getPoolRelativeWeight } from "./getRelativeWeight";
 import { Round } from "./rounds";
 
@@ -95,8 +95,8 @@ async function calculateTokensStats(
   }, 0);
 
   const tokenPromises = poolTokenData.map(async (token, idx) => {
-    const tokenPrice = await getTokenPriceByRound(
-      Round.getRoundByNumber(roundId),
+    const tokenPrice = await getTokenPriceByDate(
+      Round.getRoundByNumber(roundId).endDate,
       token.address,
       parseInt(poolNetwork),
     );

--- a/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
@@ -10,14 +10,14 @@ const BAL_TOKEN_NETWORK = 1;
 
 /**
  * Calculates the number of days between two dates, inclusive of both start and end dates.
-*/
+ */
 const calculateDaysBetween = (startDate: Date, endDate: Date) =>
   Math.floor((endDate.getTime() - startDate.getTime()) / MILLISECONDS_IN_DAY) +
   1;
 
 /**
  * Calculates the average of an array of numbers.
-*/
+ */
 const calculateAverage = (arr: number[]) =>
   arr.reduce((sum, val) => sum + val, 0) / arr.length;
 

--- a/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
@@ -12,13 +12,13 @@ export const getBALPriceByRound = async (round: Round) => {
   );
 };
 
-export const getTokenPriceByRound = async (
-  round: Round,
+export const getTokenPriceByDate = async (
+  date: Date,
   tokenAddress: string,
   tokenNetwork: number,
 ) => {
   const token = `${networkFor(tokenNetwork).toLowerCase()}:${tokenAddress}`;
-  const relevantDateForPrice = Math.min(Date.now(), round.endDate.getTime());
+  const relevantDateForPrice = Math.min(Date.now(), date.getTime());
   const api = new DefiLlamaAPI();
 
   const response = await api.getHistoricalPrice(

--- a/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
@@ -12,17 +12,13 @@ export const getBALPriceByRound = async (round: Round) =>
       {
         length:
           Math.floor(
-            (round.endDate.getTime() -
-              round.startDate.getTime()) /
+            (round.endDate.getTime() - round.startDate.getTime()) /
               MILLISECONDS_IN_DAY,
           ) + 1,
       },
       (_, i) =>
         getTokenPriceByDate(
-          new Date(
-            round.startDate.getTime() +
-              i * MILLISECONDS_IN_DAY,
-          ),
+          new Date(round.startDate.getTime() + i * MILLISECONDS_IN_DAY),
           "0xba100000625a3754423978a60c9317c58a424e3d",
           1,
         ),

--- a/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
@@ -5,34 +5,40 @@ import { DefiLlamaAPI } from "#/lib/coingecko";
 import { Round } from "./rounds";
 
 const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
+const BAL_TOKEN_ADDRESS = "0xba100000625a3754423978a60c9317c58a424e3d";
+const BAL_TOKEN_NETWORK = 1;
 
-export const getBALPriceByRound = async (round: Round) =>
-  Promise.all(
-    Array.from(
-      {
-        length:
-          Math.floor(
-            (round.endDate.getTime() - round.startDate.getTime()) /
-              MILLISECONDS_IN_DAY,
-          ) + 1,
-      },
-      (_, i) =>
-        getTokenPriceByDate(
-          new Date(round.startDate.getTime() + i * MILLISECONDS_IN_DAY),
-          "0xba100000625a3754423978a60c9317c58a424e3d",
-          1,
-        ),
+/**
+ * Calculates the number of days between two dates, inclusive of both start and end dates.
+*/
+const calculateDaysBetween = (startDate: Date, endDate: Date) =>
+  Math.floor((endDate.getTime() - startDate.getTime()) / MILLISECONDS_IN_DAY) +
+  1;
+
+/**
+ * Calculates the average of an array of numbers.
+*/
+const calculateAverage = (arr: number[]) =>
+  arr.reduce((sum, val) => sum + val, 0) / arr.length;
+
+export const getBALPriceByRound = async (round: Round) => {
+  const days = calculateDaysBetween(round.startDate, round.endDate);
+  const pricePromises = Array.from({ length: days }, (_, i) =>
+    getTokenPriceByDate(
+      new Date(round.startDate.getTime() + i * MILLISECONDS_IN_DAY),
+      BAL_TOKEN_ADDRESS,
+      BAL_TOKEN_NETWORK,
     ),
-  )
-    .then((prices) => {
-      const total = prices.reduce((sum, price) => sum + price, 0);
-      return total / prices.length;
-    })
-    .catch((error) => {
-      // eslint-disable-next-line no-console
-      console.error(error);
-      throw error;
-    });
+  );
+  try {
+    const prices = await Promise.all(pricePromises);
+    return calculateAverage(prices);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    throw error;
+  }
+};
 
 export const getTokenPriceByDate = async (
   date: Date,

--- a/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/getBALPriceByRound.ts
@@ -4,13 +4,39 @@ import { DefiLlamaAPI } from "#/lib/coingecko";
 
 import { Round } from "./rounds";
 
-export const getBALPriceByRound = async (round: Round) => {
-  return getTokenPriceByRound(
-    round,
-    "0xba100000625a3754423978a60c9317c58a424e3d",
-    1,
-  );
-};
+const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
+
+export const getBALPriceByRound = async (round: Round) =>
+  Promise.all(
+    Array.from(
+      {
+        length:
+          Math.floor(
+            (round.endDate.getTime() -
+              round.startDate.getTime()) /
+              MILLISECONDS_IN_DAY,
+          ) + 1,
+      },
+      (_, i) =>
+        getTokenPriceByDate(
+          new Date(
+            round.startDate.getTime() +
+              i * MILLISECONDS_IN_DAY,
+          ),
+          "0xba100000625a3754423978a60c9317c58a424e3d",
+          1,
+        ),
+    ),
+  )
+    .then((prices) => {
+      const total = prices.reduce((sum, price) => sum + price, 0);
+      return total / prices.length;
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      throw error;
+    });
 
 export const getTokenPriceByDate = async (
   date: Date,


### PR DESCRIPTION
This shouldn't change anything majorly, just a refactor se we use average Bal price instead of one point at the end of the round 