### PR TITLE
[Pool Simulator] Add depth cost points for fx pool based on beta limits

### DIFF
--- a/apps/balancer-tools/src/app/poolsimulator/(components)/AnalysisPage.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/AnalysisPage.tsx
@@ -1,10 +1,18 @@
 "use client";
 
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+
 import { AlertCard } from "#/components/AlertCard";
+import { Spinner } from "#/components/Spinner";
 import { Tabs } from "#/components/Tabs";
 import { usePoolSimulator } from "#/contexts/PoolSimulatorContext";
 
 import { PoolTypeEnum } from "../(types)";
+import { BetaLimits, getBetaLimits } from "../(utils)/getBetaLimits";
+import {
+  SwapCurveWorkerInputData,
+  SwapCurveWorkerOutputData,
+} from "../(workers)/swap-curve-calculation";
 import { ImpactCurve } from "./Curves/ImpactCurve";
 import { SwapCurve } from "./Curves/SwapCurve";
 import { DepthCost } from "./DepthCost";
@@ -17,16 +25,86 @@ const stablePoolTypes = [
   PoolTypeEnum.GyroE,
 ];
 
+export interface AmountsData {
+  pairTokenSymbol: string;
+  analysisTokenIn: number[];
+  analysisTokenOut: number[];
+  pairTokenIn: number[];
+  pairTokenOut: number[];
+  betaLimits?: BetaLimits;
+}
+
+const createAndPostSwapWorker = (
+  messageData: SwapCurveWorkerInputData,
+  setInitialAmounts: Dispatch<SetStateAction<AmountsData[]>>,
+  setCustomAmounts: Dispatch<SetStateAction<AmountsData[]>>,
+) => {
+  const worker = new Worker(
+    new URL("../(workers)/swap-curve-calculation.ts", import.meta.url),
+  );
+
+  worker.onmessage = (event: MessageEvent<SwapCurveWorkerOutputData>) => {
+    const result = event.data.result;
+    const type = event.data.type;
+
+    if (!result) return;
+
+    const setter = type === "initial" ? setInitialAmounts : setCustomAmounts;
+
+    setter(result);
+  };
+
+  worker.postMessage(messageData);
+};
+
 export default function Page() {
-  const { initialData, customData, analysisToken, setCurrentTabTokenByIndex } =
-    usePoolSimulator();
+  const {
+    initialData,
+    customData,
+    initialAnalysisToken,
+    customAnalysisToken,
+    setCurrentTabTokenByIndex,
+    initialCurrentTabToken: { symbol: currentTabTokenSymbol },
+  } = usePoolSimulator();
+  if (!initialData || !customData) return <Spinner />;
+
+  const [initialAmountsSwapCurve, setInitialAmountsSwapCurve] = useState<
+    AmountsData[]
+  >([{}] as AmountsData[]);
+  const [customAmountsSwapCurve, setCustomAmountsSwapCurve] = useState<
+    AmountsData[]
+  >([{}] as AmountsData[]);
+
+  useEffect(() => {
+    const messages: SwapCurveWorkerInputData[] = [
+      {
+        analysisToken: initialAnalysisToken,
+        data: initialData,
+        type: "initial",
+      },
+      {
+        analysisToken: customAnalysisToken,
+        data: customData,
+        type: "custom",
+      },
+    ];
+
+    messages.forEach((message) =>
+      createAndPostSwapWorker(
+        message,
+        setInitialAmountsSwapCurve,
+        setCustomAmountsSwapCurve,
+      ),
+    );
+  }, [initialData, customData, initialAnalysisToken, customAnalysisToken]);
 
   const indexCurrentTabToken = initialData?.tokens.findIndex(
-    ({ symbol }) => symbol.toLowerCase() !== analysisToken.symbol.toLowerCase(),
+    ({ symbol }) =>
+      symbol.toLowerCase() !== initialAnalysisToken.symbol.toLowerCase(),
   );
   const tokensSymbol = initialData.tokens.map((token) => token.symbol);
   const tabTokens = tokensSymbol.filter(
-    (token) => token !== analysisToken.symbol,
+    (token) => token !== initialAnalysisToken.symbol,
   );
 
   function handleTabClick(event: React.FormEvent<HTMLButtonElement>) {
@@ -38,6 +116,43 @@ export default function Page() {
   const poolTypes = [initialData?.poolType, customData?.poolType];
   const poolsHaveDifferentPurpose =
     poolTypes.filter((type) => stablePoolTypes.includes(type)).length == 1; // length equal one means that
+
+  const selectedInitialAmountsSwapCurve = initialAmountsSwapCurve.filter(
+    (amount) => amount.pairTokenSymbol == currentTabTokenSymbol,
+  )[0];
+
+  const selectedCustomAmountsSwapCurve = customAmountsSwapCurve.filter(
+    (amount) => amount.pairTokenSymbol == currentTabTokenSymbol,
+  )[0];
+
+  if (!selectedInitialAmountsSwapCurve || !selectedCustomAmountsSwapCurve)
+    return <Spinner />;
+
+  [initialData, customData].forEach((pool, index) => {
+    const amountData = [
+      selectedInitialAmountsSwapCurve,
+      selectedCustomAmountsSwapCurve,
+    ][index];
+    if (pool.poolType == PoolTypeEnum.Fx && pool.poolParams?.beta) {
+      const analysisData = [initialAnalysisToken, customAnalysisToken][index];
+      const pairTokens = pool.tokens.filter(
+        (token) => token.symbol !== analysisData.symbol,
+      );
+      pairTokens.forEach((pairToken) => {
+        const amounts = [initialAmountsSwapCurve, customAmountsSwapCurve][
+          index
+        ].filter((amount) => amount.pairTokenSymbol == pairToken.symbol)[0];
+        amountData.betaLimits = getBetaLimits({
+          ...amounts,
+          analysisTokenInitialBalance: analysisData?.balance || 0,
+          tabTokenInitialBalance: pairToken?.balance || 0,
+          analysisTokenRate: analysisData?.rate || 0,
+          tabTokenRate: pairToken?.rate || 0,
+          beta: pool.poolParams?.beta || 0,
+        });
+      });
+    }
+  });
 
   return (
     <>
@@ -58,7 +173,10 @@ export default function Page() {
         </div>
         <div className="w-full flex justify-center">
           <div className="w-[95%] xl:w-[95%] max-w-[calc(100vw-320px)]">
-            <DepthCost />
+            <DepthCost
+              initialBetaLimits={selectedInitialAmountsSwapCurve.betaLimits}
+              customBetaLimits={selectedCustomAmountsSwapCurve.betaLimits}
+            />
           </div>
         </div>
         <div className="w-full flex justify-center">
@@ -82,7 +200,10 @@ export default function Page() {
                 <div key={symbol}>
                   <Tabs.ItemContent tabName={symbol} classNames="bg-blue1">
                     <div className="flex flex-col gap-y-10 py-4">
-                      <SwapCurve />
+                      <SwapCurve
+                        initialAmounts={selectedInitialAmountsSwapCurve}
+                        customAmounts={selectedCustomAmountsSwapCurve}
+                      />
                       <ImpactCurve />
                     </div>
                   </Tabs.ItemContent>

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/SwapCurve.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/SwapCurve.tsx
@@ -93,18 +93,6 @@ export function SwapCurve({
     };
   };
 
-  // if (
-  //   !initialAmounts.analysisTokenIn ||
-  //   !initialAmounts.analysisTokenOut ||
-  //   !initialAmounts.pairTokenIn ||
-  //   !initialAmounts.pairTokenOut ||
-  //   !customAmounts.analysisTokenIn ||
-  //   !customAmounts.analysisTokenOut ||
-  //   !customAmounts.pairTokenIn ||
-  //   !customAmounts.pairTokenOut
-  // )
-  //   return <Spinner />;
-
   const data = [
     createDataObject(
       initialAmounts.analysisTokenIn,

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/SwapCurve.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Curves/SwapCurve.tsx
@@ -1,84 +1,28 @@
 "use client";
 
 import { PlotType } from "plotly.js";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 import Plot from "#/components/Plot";
-import { Spinner } from "#/components/Spinner";
+// import { Spinner } from "#/components/Spinner";
 import { usePoolSimulator } from "#/contexts/PoolSimulatorContext";
 import { formatNumber } from "#/utils/formatNumber";
 
-import { PoolTypeEnum } from "../../(types)";
 import { findTokenBySymbol, POOL_TYPES_TO_ADD_LIMIT } from "../../(utils)";
-import {
-  SwapCurveWorkerInputData,
-  SwapCurveWorkerOutputData,
-} from "../../(workers)/swap-curve-calculation";
-import getBetaLimitIndexes from "./getBetaLimits";
+import { AmountsData } from "../AnalysisPage";
 
-interface AmountsData {
-  analysisTokenIn: number[];
-  analysisTokenOut: number[];
-  tabTokenIn: number[];
-  tabTokenOut: number[];
-}
-
-const createAndPostSwapWorker = (
-  messageData: SwapCurveWorkerInputData,
-  setInitialAmounts: Dispatch<SetStateAction<AmountsData>>,
-  setCustomAmounts: Dispatch<SetStateAction<AmountsData>>,
-) => {
-  const worker = new Worker(
-    new URL("../../(workers)/swap-curve-calculation.ts", import.meta.url),
-  );
-
-  worker.onmessage = (event: MessageEvent<SwapCurveWorkerOutputData>) => {
-    const result = event.data.result;
-    const type = event.data.type;
-
-    if (!result) return;
-
-    const setter = type === "initial" ? setInitialAmounts : setCustomAmounts;
-
-    setter(result);
-  };
-
-  worker.postMessage(messageData);
-};
-
-export function SwapCurve() {
-  const { analysisToken, currentTabToken, initialData, customData } =
-    usePoolSimulator();
-
-  if (!initialData || !customData) return <Spinner />;
-
-  const [initialAmounts, setInitialAmounts] = useState<AmountsData>(
-    {} as AmountsData,
-  );
-  const [customAmounts, setCustomAmounts] = useState<AmountsData>(
-    {} as AmountsData,
-  );
-
-  useEffect(() => {
-    const messages: SwapCurveWorkerInputData[] = [
-      {
-        analysisToken,
-        currentTabToken,
-        data: initialData,
-        type: "initial",
-      },
-      {
-        analysisToken,
-        currentTabToken,
-        data: customData,
-        type: "custom",
-      },
-    ];
-
-    messages.forEach((message) =>
-      createAndPostSwapWorker(message, setInitialAmounts, setCustomAmounts),
-    );
-  }, [initialData, customData, analysisToken, currentTabToken]);
+export function SwapCurve({
+  initialAmounts,
+  customAmounts,
+}: {
+  initialAmounts: AmountsData;
+  customAmounts: AmountsData;
+}) {
+  const {
+    initialAnalysisToken: { symbol: analysisTokenSymbol },
+    initialCurrentTabToken: { symbol: currentTabTokenSymbol },
+    initialData,
+    customData,
+  } = usePoolSimulator();
 
   const formatSwap = (
     amountIn: number,
@@ -149,72 +93,72 @@ export function SwapCurve() {
     };
   };
 
-  if (
-    !initialAmounts.analysisTokenIn ||
-    !initialAmounts.analysisTokenOut ||
-    !initialAmounts.tabTokenIn ||
-    !initialAmounts.tabTokenOut ||
-    !customAmounts.analysisTokenIn ||
-    !customAmounts.analysisTokenOut ||
-    !customAmounts.tabTokenIn ||
-    !customAmounts.tabTokenOut
-  )
-    return <Spinner />;
+  // if (
+  //   !initialAmounts.analysisTokenIn ||
+  //   !initialAmounts.analysisTokenOut ||
+  //   !initialAmounts.pairTokenIn ||
+  //   !initialAmounts.pairTokenOut ||
+  //   !customAmounts.analysisTokenIn ||
+  //   !customAmounts.analysisTokenOut ||
+  //   !customAmounts.pairTokenIn ||
+  //   !customAmounts.pairTokenOut
+  // )
+  //   return <Spinner />;
 
   const data = [
     createDataObject(
       initialAmounts.analysisTokenIn,
-      initialAmounts.tabTokenOut,
+      initialAmounts.pairTokenOut,
       "Initial",
       true,
       initialAmounts.analysisTokenIn.map((amount, index) =>
         formatSwap(
           amount,
-          analysisToken.symbol,
-          -initialAmounts.tabTokenOut[index],
-          currentTabToken.symbol,
+          analysisTokenSymbol,
+          -initialAmounts.pairTokenOut[index],
+          currentTabTokenSymbol,
         ),
       ),
     ),
     createDataObject(
       customAmounts.analysisTokenIn,
-      customAmounts.tabTokenOut,
+      customAmounts.pairTokenOut,
       "Custom",
       true,
       customAmounts.analysisTokenIn.map((amount, index) =>
         formatSwap(
           amount,
-          analysisToken.symbol,
-          -customAmounts.tabTokenOut[index],
-          currentTabToken.symbol,
+          analysisTokenSymbol,
+          -customAmounts.pairTokenOut[index],
+          currentTabTokenSymbol,
         ),
       ),
     ),
     createDataObject(
       initialAmounts.analysisTokenOut,
-      initialAmounts.tabTokenIn,
+      initialAmounts.pairTokenIn,
       "Initial",
       false,
       initialAmounts.analysisTokenOut.map((amount, index) =>
         formatSwap(
-          initialAmounts.tabTokenIn[index],
-          currentTabToken.symbol,
+          initialAmounts.pairTokenIn[index],
+          currentTabTokenSymbol,
           -amount,
-          analysisToken.symbol,
+          analysisTokenSymbol,
         ),
       ),
     ),
     createDataObject(
       customAmounts.analysisTokenOut,
-      customAmounts.tabTokenIn,
+      customAmounts.pairTokenIn,
       "Custom",
       false,
       customAmounts.analysisTokenOut.map((amount, index) =>
         formatSwap(
-          customAmounts.tabTokenIn[index],
-          currentTabToken.symbol,
+          customAmounts.pairTokenIn[index],
+          currentTabTokenSymbol,
           -amount,
-          analysisToken.symbol,
+          analysisTokenSymbol,
         ),
       ),
     ),
@@ -228,8 +172,8 @@ export function SwapCurve() {
           initialAmounts.analysisTokenIn.slice(-1)[0],
         ],
         [
-          initialAmounts.tabTokenIn.slice(-1)[0],
-          initialAmounts.tabTokenOut.slice(-1)[0],
+          initialAmounts.pairTokenIn.slice(-1)[0],
+          initialAmounts.pairTokenOut.slice(-1)[0],
         ],
         "Initial",
       ),
@@ -243,37 +187,23 @@ export function SwapCurve() {
           customAmounts.analysisTokenIn.slice(-1)[0],
         ],
         [
-          customAmounts.tabTokenIn.slice(-1)[0],
-          customAmounts.tabTokenOut.slice(-1)[0],
+          customAmounts.pairTokenIn.slice(-1)[0],
+          customAmounts.pairTokenOut.slice(-1)[0],
         ],
         "Custom",
       ),
     );
   }
-  const poolData = [initialData, customData];
-  const amounts = [initialAmounts, customAmounts];
-  const legends = ["Initial", "Custom"];
 
-  poolData.forEach((pool, index) => {
-    if (pool.poolType == PoolTypeEnum.Fx && pool.poolParams?.beta) {
-      const analysisData = findTokenBySymbol(pool.tokens, analysisToken.symbol);
-      const tabData = findTokenBySymbol(pool.tokens, currentTabToken.symbol);
-      const betaLimits = getBetaLimitIndexes({
-        ...amounts[index],
-        analysisTokenInitialBalance: analysisData?.balance || 0,
-        tabTokenInitialBalance: tabData?.balance || 0,
-        analysisTokenRate: analysisData?.rate || 0,
-        tabTokenRate: tabData?.rate || 0,
-        beta: pool.poolParams.beta,
-      });
-      data.push(
-        createBetaRegionDataObject(
-          betaLimits[0],
-          betaLimits[1],
-          legends[index],
-        ),
-      );
-    }
+  [initialAmounts, customAmounts].forEach((amounts, index) => {
+    if (!amounts.betaLimits) return;
+    data.push(
+      createBetaRegionDataObject(
+        amounts.betaLimits.analysis,
+        amounts.betaLimits.pair,
+        ["Initial", "Custom"][index],
+      ),
+    );
   });
 
   function getGraphScale({
@@ -339,17 +269,17 @@ export function SwapCurve() {
       data={data}
       layout={{
         xaxis: {
-          title: `Amount of ${analysisToken.symbol}`,
+          title: `Amount of ${analysisTokenSymbol}`,
           range: getGraphScale({
-            axisBalanceSymbol: analysisToken.symbol,
-            oppositeAxisBalanceSymbol: currentTabToken.symbol,
+            axisBalanceSymbol: analysisTokenSymbol,
+            oppositeAxisBalanceSymbol: currentTabTokenSymbol,
           }),
         },
         yaxis: {
-          title: `Amount of ${currentTabToken.symbol}`,
+          title: `Amount of ${currentTabTokenSymbol}`,
           range: getGraphScale({
-            axisBalanceSymbol: currentTabToken.symbol,
-            oppositeAxisBalanceSymbol: analysisToken.symbol,
+            axisBalanceSymbol: currentTabTokenSymbol,
+            oppositeAxisBalanceSymbol: analysisTokenSymbol,
           }),
         },
       }}

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/DepthCost.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/DepthCost.tsx
@@ -347,6 +347,8 @@ export function calculateDepthCost(
         type: "2% of price change",
       };
     case PoolTypeEnum.Fx:
+      // For FX pools we'll assume depth cost as the beta region limit
+      // if the pool is already outside of the beta region, 0 will be displayed
       const betaLimitAmount =
         poolSide === "in"
           ? betaLimits?.analysisTokenIn.analysisAmount
@@ -363,7 +365,7 @@ export function calculateDepthCost(
         type: "beta region limit",
       };
     default:
-      return { amount: -1, type: "" };
+      return { amount: 0, type: "" };
   }
 }
 

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/Menu.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/Menu.tsx
@@ -238,7 +238,7 @@ export function AnalysisMenu() {
     customData,
     setCustomData,
     setAnalysisTokenByIndex,
-    analysisToken,
+    initialAnalysisToken,
     setCurrentTabTokenByIndex,
   } = usePoolSimulator();
 
@@ -251,7 +251,8 @@ export function AnalysisMenu() {
   }, []);
 
   const indexCurrentTabToken = initialData?.tokens.findIndex(
-    ({ symbol }) => symbol.toLowerCase() !== analysisToken.symbol.toLowerCase(),
+    ({ symbol }) =>
+      symbol.toLowerCase() !== initialAnalysisToken.symbol.toLowerCase(),
   );
 
   return (

--- a/apps/balancer-tools/src/app/poolsimulator/(utils)/getBetaLimits.test.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(utils)/getBetaLimits.test.ts
@@ -1,6 +1,7 @@
-import getBetaLimits, {
+import {
   computeSwapAmounts,
   findTransitions,
+  getBetaLimits,
   getTransitionIndices,
   isInBetaRegion,
 } from "./getBetaLimits";

--- a/apps/balancer-tools/src/app/poolsimulator/(utils)/getBetaLimits.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(utils)/getBetaLimits.ts
@@ -54,10 +54,6 @@ export function getTransitionIndices(booleans: boolean[]): number[] {
     throw new Error("The true values are not continuous.");
   }
 
-  // if (end === booleans.length) {
-  //   throw new Error("Not found one of the boundaries");
-  // }
-
   return end === start ? [start] : [start, end];
 }
 
@@ -106,17 +102,6 @@ export function getBetaLimits({
   tabTokenInitialBalance: number;
   beta: number;
 }): BetaLimits {
-  // console.log({
-  //   analysisTokenOut,
-  //   analysisTokenIn,
-  //   pairTokenIn,
-  //   analysisTokenRate,
-  //   tabTokenRate,
-  //   pairTokenOut,
-  //   analysisTokenInitialBalance,
-  //   tabTokenInitialBalance,
-  //   beta,
-  // });
   // https://docs.xave.co/product-overview-1/fxpools/amm-faqs
   const analysisAmounts = computeSwapAmounts(analysisTokenOut, analysisTokenIn);
   const tabAmounts = computeSwapAmounts(pairTokenIn, pairTokenOut);

--- a/apps/balancer-tools/src/app/poolsimulator/(workers)/swap-curve-calculation.ts
+++ b/apps/balancer-tools/src/app/poolsimulator/(workers)/swap-curve-calculation.ts
@@ -5,15 +5,10 @@ import { AnalysisData } from "#/contexts/PoolSimulatorContext";
 import { trimTrailingValues } from "#/lib/utils";
 
 import { TokensData } from "../(types)";
-import {
-  calculateCurvePoints,
-  convertAnalysisDataToAMM,
-  findTokenBySymbol,
-} from "../(utils)";
+import { calculateCurvePoints, convertAnalysisDataToAMM } from "../(utils)";
 
 export interface SwapCurveWorkerInputData {
   analysisToken: TokensData;
-  currentTabToken: TokensData;
   data: AnalysisData;
   type: "initial" | "custom";
 }
@@ -22,9 +17,10 @@ export interface SwapCurveWorkerOutputData {
   result?: {
     analysisTokenIn: number[];
     analysisTokenOut: number[];
-    tabTokenOut: number[];
-    tabTokenIn: number[];
-  };
+    pairTokenOut: number[];
+    pairTokenIn: number[];
+    pairTokenSymbol: string;
+  }[];
   error?: Error;
   type: "initial" | "custom";
 }
@@ -32,7 +28,7 @@ export interface SwapCurveWorkerOutputData {
 self.addEventListener(
   "message",
   async (event: MessageEvent<SwapCurveWorkerInputData>) => {
-    const { analysisToken, currentTabToken, data, type } = event.data;
+    const { analysisToken, data, type } = event.data;
 
     if (!data) return;
 
@@ -40,55 +36,75 @@ self.addEventListener(
 
     if (!amm) return;
 
-    const calculateTokenAmounts = (
-      tokenIn: TokensData,
-      tokenOut: TokensData,
-      amm: AMM<PoolPairData>,
-    ) => {
-      const rawAmountsAnalysisTokenIn = calculateCurvePoints({
-        balance: tokenOut.balance,
-      });
-
-      const rawAmountsTabTokenIn = calculateCurvePoints({
-        balance: tokenIn.balance,
-      });
-
-      const rawAmountsTabTokenOut = rawAmountsAnalysisTokenIn.map(
-        (amount) =>
-          amm.exactTokenInForTokenOut(amount, tokenIn.symbol, tokenOut.symbol) *
-          -1,
-      );
-
-      const rawAmountsAnalysisTokenOut = rawAmountsTabTokenIn.map(
-        (amount) =>
-          amm.exactTokenInForTokenOut(amount, tokenOut.symbol, tokenIn.symbol) *
-          -1,
-      );
-
-      const { trimmedIn: tabTokenIn, trimmedOut: analysisTokenOut } =
-        trimTrailingValues(rawAmountsTabTokenIn, rawAmountsAnalysisTokenOut, 0);
-
-      const { trimmedIn: analysisTokenIn, trimmedOut: tabTokenOut } =
-        trimTrailingValues(rawAmountsAnalysisTokenIn, rawAmountsTabTokenOut, 0);
-
-      return {
-        analysisTokenIn: analysisTokenIn as number[],
-        analysisTokenOut: analysisTokenOut as number[],
-        tabTokenOut: tabTokenOut as number[],
-        tabTokenIn: tabTokenIn as number[],
-      };
-    };
-
-    const calcResult = calculateTokenAmounts(
-      findTokenBySymbol(data?.tokens, analysisToken.symbol) as TokensData,
-      findTokenBySymbol(data?.tokens, currentTabToken.symbol) as TokensData,
-      amm,
+    const pairTokens = data.tokens.filter(
+      (token) => token.symbol !== analysisToken.symbol,
     );
 
-    const result: SwapCurveWorkerOutputData = {
-      result: calcResult,
+    const result = pairTokens.map((pairToken) => {
+      const calculateTokenAmounts = (
+        tokenIn: TokensData,
+        tokenOut: TokensData,
+        amm: AMM<PoolPairData>,
+      ) => {
+        const rawAmountsAnalysisTokenIn = calculateCurvePoints({
+          balance: tokenOut.balance,
+        });
+
+        const rawAmountsTabTokenIn = calculateCurvePoints({
+          balance: tokenIn.balance,
+        });
+
+        const rawAmountsTabTokenOut = rawAmountsAnalysisTokenIn.map(
+          (amount) =>
+            amm.exactTokenInForTokenOut(
+              amount,
+              tokenIn.symbol,
+              tokenOut.symbol,
+            ) * -1,
+        );
+
+        const rawAmountsAnalysisTokenOut = rawAmountsTabTokenIn.map(
+          (amount) =>
+            amm.exactTokenInForTokenOut(
+              amount,
+              tokenOut.symbol,
+              tokenIn.symbol,
+            ) * -1,
+        );
+
+        const { trimmedIn: tabTokenIn, trimmedOut: analysisTokenOut } =
+          trimTrailingValues(
+            rawAmountsTabTokenIn,
+            rawAmountsAnalysisTokenOut,
+            0,
+          );
+
+        const { trimmedIn: analysisTokenIn, trimmedOut: tabTokenOut } =
+          trimTrailingValues(
+            rawAmountsAnalysisTokenIn,
+            rawAmountsTabTokenOut,
+            0,
+          );
+
+        return {
+          analysisTokenIn: analysisTokenIn as number[],
+          analysisTokenOut: analysisTokenOut as number[],
+          pairTokenOut: tabTokenOut as number[],
+          pairTokenIn: tabTokenIn as number[],
+          pairTokenSymbol: pairToken.symbol as string,
+        };
+      };
+
+      return calculateTokenAmounts(
+        analysisToken as TokensData,
+        pairToken as TokensData,
+        amm,
+      );
+    });
+
+    self.postMessage({
+      result,
       type,
-    };
-    self.postMessage(result);
+    } as SwapCurveWorkerOutputData);
   },
 );

--- a/apps/balancer-tools/src/contexts/PoolSimulatorContext.tsx
+++ b/apps/balancer-tools/src/contexts/PoolSimulatorContext.tsx
@@ -46,8 +46,10 @@ export enum DataType {
 interface PoolSimulatorContextType {
   initialData: AnalysisData;
   customData: AnalysisData;
-  analysisToken: TokensData;
-  currentTabToken: TokensData;
+  initialAnalysisToken: TokensData;
+  customAnalysisToken: TokensData;
+  initialCurrentTabToken: TokensData;
+  customCurrentTabToken: TokensData;
   setAnalysisTokenBySymbol: (symbol: string) => void;
   setCurrentTabTokenBySymbol: (symbol: string) => void;
   setAnalysisTokenByIndex: (index: number) => void;
@@ -100,31 +102,51 @@ export function PoolSimulatorProvider({ children }: PropsWithChildren) {
     useState<AnalysisData>(defaultAnalysisData);
   const [initialAMM, setInitialAMM] = useState<AMM<PoolPairData>>();
   const [customAMM, setCustomAMM] = useState<AMM<PoolPairData>>();
-  const [analysisToken, setAnalysisToken] =
+  const [initialAnalysisToken, setInitialAnalysisToken] =
     useState<TokensData>(defaultTokensData);
-  const [currentTabToken, setCurrentTabToken] =
+  const [customAnalysisToken, setCustomAnalysisToken] =
+    useState<TokensData>(defaultTokensData);
+  const [initialCurrentTabToken, setInitialCurrentTabToken] =
+    useState<TokensData>(defaultTokensData);
+  const [customCurrentTabToken, setCustomCurrentTabToken] =
     useState<TokensData>(defaultTokensData);
 
   const [isGraphLoading, setIsGraphLoading] = useState<boolean>(false);
 
   function setAnalysisTokenBySymbol(symbol: string) {
-    const token = initialData.tokens.find((token) => token.symbol === symbol);
-    if (token) setAnalysisToken(token);
+    const initialToken = initialData.tokens.find(
+      (token) => token.symbol === symbol,
+    );
+    const customToken = customData.tokens.find(
+      (token) => token.symbol === symbol,
+    );
+    if (initialToken) setInitialAnalysisToken(initialToken);
+    if (customToken) setCustomAnalysisToken(customToken);
   }
 
   function setCurrentTabTokenBySymbol(symbol: string) {
-    const token = initialData.tokens.find((token) => token.symbol === symbol);
-    if (token) setCurrentTabToken(token);
+    const initialToken = initialData.tokens.find(
+      (token) => token.symbol === symbol,
+    );
+    const customToken = customData.tokens.find(
+      (token) => token.symbol === symbol,
+    );
+    if (initialToken) setInitialCurrentTabToken(initialToken);
+    if (customToken) setCustomCurrentTabToken(customToken);
   }
 
   function setAnalysisTokenByIndex(index: number) {
-    const token = initialData.tokens[index];
-    if (token) setAnalysisToken(token);
+    const initialToken = initialData.tokens[index];
+    const customToken = customData.tokens[index];
+    if (initialToken) setInitialAnalysisToken(initialToken);
+    if (customToken) setCustomAnalysisToken(customToken);
   }
 
   function setCurrentTabTokenByIndex(index: number) {
-    const token = initialData.tokens[index];
-    if (token) setCurrentTabToken(token);
+    const initialToken = initialData.tokens[index];
+    const customToken = customData.tokens[index];
+    if (initialToken) setInitialCurrentTabToken(initialToken);
+    if (customToken) setCustomCurrentTabToken(customToken);
   }
 
   async function asyncSetAMM(
@@ -193,10 +215,12 @@ export function PoolSimulatorProvider({ children }: PropsWithChildren) {
         setInitialData,
         customData,
         setCustomData,
-        analysisToken,
+        initialAnalysisToken,
+        customAnalysisToken,
+        initialCurrentTabToken,
+        customCurrentTabToken,
         setAnalysisTokenBySymbol,
         setAnalysisTokenByIndex,
-        currentTabToken,
         setCurrentTabTokenBySymbol,
         setCurrentTabTokenByIndex,
         handleImportPoolParametersById,


### PR DESCRIPTION
This PR:
- Refactor swap curve points calculations to AnalysisPage component;
- Refactor `analysisToken` to `initialAnalysisToken` and `customAnalysisToken` to avoid get this data with `findTokenBySymbol` function multiple times on the app;
- Use beta limits points (from swap curve) on Depth Cost Chart
- Add warning on the depth cost chart in case on pool already outside of the beta region.

<img width="883" alt="image" src="https://github.com/bleu-studio/balancer-tools/assets/55461956/626ccf26-e1e7-4b34-80b4-03f69131933c">
