### PR TITLE
[APR] Handle bb tokens on yield apr

### DIFF
--- a/apps/balancer-tools/src/app/apr/(utils)/tokenYield.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/tokenYield.ts
@@ -6,6 +6,7 @@ import { blocks, pools } from "#/lib/gql/server";
 
 import { ChainName, publicClients } from "./chainsPublicClients";
 import { manualPoolsRateProvider } from "./poolsRateProvider";
+import { vunerabilityAffecteRateProviders } from "./vunerabilityAffectedPool";
 
 const rateProviderAbi = [
   {
@@ -61,6 +62,15 @@ const getAPRFromRateProviderInterval = withCache(
     timeEnd: number,
     chainName: ChainName,
   ) {
+    if (
+      timeEnd >= 1692662400 && // pool vunerability was found on August 22
+      vunerabilityAffecteRateProviders.some(
+        ({ address }) => address === rateProviderAddress,
+      )
+    ) {
+      return 0;
+    }
+
     const { endRate, startRate } = await getIntervalRates(
       rateProviderAddress,
       timeStart,

--- a/apps/balancer-tools/src/app/apr/(utils)/vunerabilityAffectedPool.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/vunerabilityAffectedPool.ts
@@ -1,0 +1,19 @@
+import { Address } from "@bleu-balancer-tools/utils";
+
+export const vunerabilityAffecteRateProviders: {
+  token: string;
+  address: Address;
+}[] = [
+  {
+    token: "bb-a-USDC",
+    address: "0x89b28a9494589b09dbccb69911c189f74fdadc5a",
+  },
+  {
+    token: "bb-a-DAI",
+    address: "0xa5fe91dde37d8bf2dacacc0168b115d28ed03f84",
+  },
+  {
+    token: "bb-a-USDT",
+    address: "0xb59be8f3c85a9dd6e2899103b6fbf6ea405b99a4",
+  },
+];


### PR DESCRIPTION
This PR returns APR as 0 for bb-tokens affected by the vulnerability after 22th Aug.

It will return values prior to 22th Aug, but they seem to be too small

![image](https://github.com/bleu-studio/balancer-tools/assets/63298341/b0f9f6a0-ac5b-4d6b-9361-810f007237cf)
